### PR TITLE
Issue#29: Fix NaN weights from missing visibilities.

### DIFF
--- a/ps_core/fhd_file_setup.pro
+++ b/ps_core/fhd_file_setup.pro
@@ -655,10 +655,11 @@ function fhd_file_setup, filename, weightfile = weightfile, variancefile = varia
           endelse
           
           if j eq 0 then vis_noise = fltarr(npol, nfiles, n_freq)
-          vis_noise[pol_i, file_i, *] = sqrt(total(vis_noise_arr^2.*n_vis_freq_arr, 1)/total(n_vis_freq_arr, 1))
-          wh_zero = where(total(n_vis_freq_arr, 1) eq 0, count_zero)
-          if count_zero gt 0 then vis_noise_arr[wh_zero] = 0
-          undefine, wh_zero, count_zero
+          vis_noise_temp = sqrt(total(vis_noise_arr^2.*n_vis_freq_arr, 1)
+          wh_nonzero = where(total(n_vis_freq_arr, 1) ne 0, count_nonzero)
+          if count_nonzero gt 0 then vis_noise_temp[wh_nonzero]/=(total(n_vis_freq_arr, 1)))[wh_nonzero]
+          vis_noise[pol_i, file_i, *] = vis_noise_temp
+          undefine, wh_nonzero, count_nonzero, vis_noise_temp
           
         endif
         


### PR DESCRIPTION
This attempts to fix the bug reported in issue #29 where the weights were contaminated with NaNs if there was missing data. 
I took it on thinking it was an FHD issue, since I didn't look too closely at the repo, but hopefully my changes reflect the original code's intent.