### PR TITLE
Do Not Merge: Reorganize output into logical subfolders

### DIFF
--- a/ps_compare/compare_plot_prep.pro
+++ b/ps_compare/compare_plot_prep.pro
@@ -590,13 +590,27 @@ pro compare_plot_prep, folder_names, obs_info, ps_foldernames = ps_foldernames, 
           endfor
 
           input_savefile1[slice_i, cube_i] = file_struct_arr1[type_pol_locs[cube_i, 0]].power_savefile
-          if file_test(input_savefile1[slice_i, cube_i]) eq 0 then begin
+          file_test1 = file_valid(input_savefile1[slice_i, cube_i])
+          if not file_test1 then begin
+            this_file_struct = file_struct_arr1[type_pol_locs[cube_i, 0]]
+            file_test1 = check_old_path(this_file_struct, 'power_savefile')
+            file_struct_arr1[type_pol_locs[cube_i, 0]] = this_file_struct
+            input_savefile1[slice_i, cube_i] = file_struct_arr1[type_pol_locs[cube_i, 0]].power_savefile
+          endif
+          if file_test1 eq 0 then begin
             message, 'No power file for ' + type_pol1 + ' and info_file: ' + $
               obs_info.info_files[0]
           endif
 
           input_savefile2[slice_i, cube_i] = file_struct_arr2[type_pol_locs[cube_i, 1]].power_savefile
-          if file_test(input_savefile2[slice_i, cube_i]) eq 0 then begin
+          file_test2 = file_valid(input_savefile2[slice_i, cube_i])
+          if not file_test2 then begin
+            this_file_struct = file_struct_arr2[type_pol_locs[cube_i, 1]]
+            file_test2 = check_old_path(this_file_struct, 'power_savefile')
+            file_struct_arr2[type_pol_locs[cube_i, 1]] = this_file_struct
+            input_savefile2[slice_i, cube_i] = file_struct_arr2[type_pol_locs[cube_i, 1]].power_savefile
+          endif
+          if file_test2 eq 0 then begin
             message, 'No power file for ' + type_pol2 + ' and info_file: ' + $
               obs_info.info_files[n_elements(obs_info.info_files)-1]
           endif
@@ -608,12 +622,45 @@ pro compare_plot_prep, folder_names, obs_info, ps_foldernames = ps_foldernames, 
             file_struct_arr1[type_pol_locs[cube_i, 0]].savefilebase + $
             file_struct_arr1[type_pol_locs[cube_i, 0]].power_tag + fadd_2dbin + $
             kperp_density_names[0] + '_2dkpower.idlsave'
+
+          file_test1 = file_valid(input_savefile1[slice_i, cube_i])
+          if not file_test1 then begin
+            old_file = file_struct_arr1[type_pol_locs[cube_i, 0]].savefile_froot + $
+              file_struct_arr1[type_pol_locs[cube_i, 0]].savefilebase + $
+              file_struct_arr1[type_pol_locs[cube_i, 0]].power_tag + fadd_2dbin + $
+              kperp_density_names[0] + '_2dkpower.idlsave'
+            file_test_old = file_valid(old_file)
+            if file_test_old then begin
+              input_savefile1[slice_i, cube_i] = old_file
+              file_test1 = file_test_old
+            endif
+          endif
+          if not file_test1 then begin
+            message, '2D input file ' + input_savefile1[slice_i, cube_i] + ' not found'
+          endif
+
           input_savefile2[slice_i, cube_i] = file_struct_arr2[type_pol_locs[cube_i, 1]].savefile_froot + $
             file_struct_arr2[type_pol_locs[cube_i, 0]].subfolders.data + $
             file_struct_arr2[type_pol_locs[cube_i, 0]].subfolders.bin_2d + $
             file_struct_arr2[type_pol_locs[cube_i, 1]].savefilebase + $
             file_struct_arr2[type_pol_locs[cube_i, 1]].power_tag + fadd_2dbin + $
             kperp_density_names[n_wtcuts-1] + '_2dkpower.idlsave'
+
+            file_test2 = file_valid(input_savefile2[slice_i, cube_i])
+            if not file_test2 then begin
+              old_file = file_struct_arr2[type_pol_locs[cube_i, 1]].savefile_froot + $
+              file_struct_arr2[type_pol_locs[cube_i, 1]].savefilebase + $
+              file_struct_arr2[type_pol_locs[cube_i, 1]].power_tag + fadd_2dbin + $
+              kperp_density_names[n_wtcuts-1] + '_2dkpower.idlsave'
+              file_test_old = file_valid(old_file)
+              if file_test_old then begin
+                input_savefile2[slice_i, cube_i] = old_file
+                file_test2 = file_test_old
+              endif
+            endif
+            if not file_test2 then begin
+              message, '2D input file ' + input_savefile2[slice_i, cube_i] + ' not found'
+            endif
 
         endelse
       endelse

--- a/ps_compare/ps_differences.pro
+++ b/ps_compare/ps_differences.pro
@@ -3,16 +3,16 @@ pro ps_differences, power_file1, power_file2, refresh = refresh, $
     wedge_amp = wedge_amp, wt_cutoffs = wt_cutoffs, wt_measures = wt_measures, $
     plot_options = plot_options
 
-  test_save = file_test(savefile_3d) *  (1 - file_test(savefile_3d, /zero_length))
-  test_save_2d = file_test(savefile_2d) *  (1 - file_test(savefile_2d, /zero_length))
-  test_save_1d = file_test(reform(savefiles_1d)) *  (1 - file_test(reform(savefiles_1d) , /zero_length))
+  test_save = file_valid(savefile_3d)
+  test_save_2d = file_valid(savefile_2d)
+  test_save_1d = file_valid(reform(savefiles_1d))
 
   if test_save eq 0 or keyword_set(refresh) then begin
 
-    if file_test(power_file1) eq 0 then begin
+    if file_valid(power_file1) eq 0 then begin
       message, 'file not found: ' + power_file1
     endif
-    if file_test(power_file2) eq 0 then begin
+    if file_valid(power_file2) eq 0 then begin
       message, 'file not found: ' + power_file2
     endif
 

--- a/ps_core/ps_image_to_uvf.pro
+++ b/ps_core/ps_image_to_uvf.pro
@@ -19,15 +19,19 @@ pro ps_image_to_uvf, file_struct, n_vis_freq, kx_rad_vals, ky_rad_vals, $
   
   for i=0, nfiles-1 do begin
     test_uvf = file_valid(file_struct.uvf_savefile[i])
-    
+    if not test_uvf then test_uvf = check_old_path(file_struct, 'uvf_savefile', index=i)
+
     test_wt_uvf = file_valid(file_struct.uvf_weight_savefile[i])
-    
+    if not test_wt_uvf then test_wt_uvf = check_old_path(file_struct, 'uvf_weight_savefile', index=i)
+
     if tag_exist(file_struct, 'beam_savefile') then begin
       test_beam = file_valid(file_struct.beam_savefile[i])
+      if not test_beam then test_beam = check_old_path(file_struct, 'beam_savefile', index=i)
     endif else test_beam = 1
     
     test_radec_uvf = file_valid(file_struct.radec_file)
-    
+    if not test_radec_uvf then test_radec_uvf = check_old_path(file_struct, 'radec_file')
+
     if test_uvf eq 1 and n_elements(freq_flags) ne 0 then begin
       old_freq_mask = getvar_savefile(file_struct.uvf_savefile[i], 'freq_mask')
       if total(abs(old_freq_mask - freq_mask)) ne 0 then test_uvf = 0
@@ -50,7 +54,8 @@ pro ps_image_to_uvf, file_struct, n_vis_freq, kx_rad_vals, ky_rad_vals, $
         full_uvf_file = strjoin(strsplit(full_uvf_file, '_flag[a-z0-9]+', /regex, /extract))
       endif
       test_full_uvf = file_valid(full_uvf_file)
-      
+      if not test_full_uvf then test_full_uvf = check_old_path(file_struct, 'uvf_savefile', index=i)
+
       if test_full_uvf eq 1 then begin
         restore, full_uvf_file
         
@@ -90,7 +95,8 @@ pro ps_image_to_uvf, file_struct, n_vis_freq, kx_rad_vals, ky_rad_vals, $
           /regex, /extract))
       endif
       test_full_wt_uvf = file_valid(full_uvf_wt_file)
-      
+      if not test_full_wt_uvf then test_full_wt_uvf = check_old_path(file_struct, 'uvf_weight_savefile', index=i)
+
       if test_full_wt_uvf eq 1 then begin
         restore, full_uvf_wt_file
         
@@ -129,9 +135,11 @@ pro ps_image_to_uvf, file_struct, n_vis_freq, kx_rad_vals, ky_rad_vals, $
         ;; from uvf_savefiles
       
         test_input_uvf = intarr(2)
-        test_input_uvf [0] =  file_valid(input_uvf_files[i,0])
-        test_input_uvf [1] =  file_valid(input_uvf_files[i,1])
-        
+        test_input_uvf[0] =  file_valid(input_uvf_files[i,0])
+        if not test_input_uvf[0] then test_input_uvf[0] = check_old_path(file_struct, 'derived_uvf_inputfiles', index=i)
+        test_input_uvf[1] =  file_valid(input_uvf_files[i,1])
+        if not test_input_uvf[0] then test_input_uvf[0] = check_old_path(file_struct, 'derived_uvf_inputfiles', index=nfiles+i)
+
         if min(test_input_uvf) eq 1 and (n_elements(freq_ch_range) ne 0 $
           or n_elements(freq_flags) ne 0) then begin
           
@@ -149,7 +157,8 @@ pro ps_image_to_uvf, file_struct, n_vis_freq, kx_rad_vals, ky_rad_vals, $
                   /regex, /extract))
               endif
               test_full_uvf = file_valid(full_uvf_file)
-              
+              if not test_full_uvf then test_full_uvf = check_old_path(file_struct, 'derived_uvf_inputfiles', index=j*nfiles+i)
+
               if test_full_uvf eq 1 then begin
                 restore, full_uvf_file
                 

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -263,6 +263,8 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
     ;; get beam sorted out
     if tag_exist(file_struct, 'beam_savefile') then begin
       test_beam = file_valid(file_struct.beam_savefile)
+      if not test_beam then test_beam = check_old_path(file_struct, 'beam_savefile')
+
       if min(test_beam) eq 0 or refresh_options.refresh_beam then begin
 
         for i=0, nfiles-1 do begin

--- a/ps_core/ps_main_plots.pro
+++ b/ps_core/ps_main_plots.pro
@@ -40,12 +40,12 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
   print, 'file setup time: ' + number_formatter(time1-time0)
 
   ;; make sure save paths exist
-  save_paths = file_struct_arr(0).savefile_froot + file_struct_arr(0).subfolders.data + $
-    ['', file_struct_arr(0).subfolders.uvf + ['', file_struct_arr(0).subfolders.slices], $
-     file_struct_arr(0).subfolders.kspace + ['', file_struct_arr(0).subfolders.slices], $
-     file_struct_arr(0).subfolders.beams, $
-     file_struct_arr(0).subfolders.bin_2d + ['', 'from_1d/'], $
-     file_struct_arr(0).subfolders.bin_1d]
+  save_paths = file_struct_arr[0].savefile_froot + file_struct_arr[0].subfolders.data + $
+    ['', file_struct_arr[0].subfolders.uvf + ['', file_struct_arr[0].subfolders.slices], $
+     file_struct_arr[0].subfolders.kspace + ['', file_struct_arr[0].subfolders.slices], $
+     file_struct_arr[0].subfolders.beams, $
+     file_struct_arr[0].subfolders.bin_2d + ['', 'from_1d/'], $
+     file_struct_arr[0].subfolders.bin_1d]
   for i = 0, n_elements(save_paths) - 1 do begin
     if not file_test(save_paths[i], /directory) then file_mkdir, save_paths[i]
   endfor
@@ -54,14 +54,13 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
     if tag_exist(plot_options, 'plot_path') ne 0 then begin
       plotfile_path = plot_options.plot_path
     endif else begin
-      plotfile_path = file_struct_arr(0).savefile_froot + file_struct_arr(0).subfolders.plots
+      plotfile_path = file_struct_arr[0].savefile_froot + file_struct_arr[0].subfolders.plots
     endelse
 
     ;; make sure plot paths exist
-    plot_paths = file_struct_arr(0).savefile_froot + file_struct_arr(0).subfolders.plots + $
-      ['', file_struct_arr(0).subfolders.slices, $
-       file_struct_arr(0).subfolders.bin_2d + ['', 'from_1d/'], $
-       file_struct_arr(0).subfolders.bin_1d + ['', 'bin_histograms/']]
+    plot_paths = plotfile_path + ['', file_struct_arr[0].subfolders.slices, $
+       file_struct_arr[0].subfolders.bin_2d + ['', 'from_1d/'], $
+       file_struct_arr[0].subfolders.bin_1d + ['', 'bin_histograms/']]
     for i = 0, n_elements(plot_paths) - 1 do begin
       if not file_test(plot_paths[i], /directory) then file_mkdir, plot_paths[i]
     endfor
@@ -380,7 +379,7 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
   if count_std gt 0 then kperp_density_names[wh_std] = '_dencorr'
 
   ;; need general_filebase for 1D plotfiles, make sure it doesn't have a full path
-  general_filebase = file_struct_arr(0).general_filebase
+  general_filebase = file_struct_arr[0].general_filebase
   for i=0, n_cubes-1 do begin
     if file_struct_arr(i).general_filebase ne general_filebase then begin
       message, 'general_filebase does not match between 1d savefiles'
@@ -388,8 +387,8 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
   endfor
 
   savefiles_2d = strarr(n_cubes, n_elements(kperp_density_names))
-  bin_2d_path = file_struct_arr.savefile_froot + file_struct_arr(0).subfolders.data + $
-    file_struct_arr(0).subfolders.bin_2d
+  bin_2d_path = file_struct_arr.savefile_froot + file_struct_arr[0].subfolders.data + $
+    file_struct_arr[0].subfolders.bin_2d
   for j=0, n_elements(kperp_density_names)-1 do begin
     savefiles_2d[*,j] = bin_2d_path + file_struct_arr.savefilebase + $
       power_tag + fadd_2dbin + kperp_density_names[j] + '_2dkpower.idlsave'
@@ -397,8 +396,8 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
   test_save_2d = file_valid(savefiles_2d)
 
   savefiles_1d = strarr(n_cubes, n_elements(kperp_density_names), n_elements(wedge_1dbin_names))
-  bin_1d_path = file_struct_arr.savefile_froot + file_struct_arr(0).subfolders.data + $
-    file_struct_arr(0).subfolders.bin_1d
+  bin_1d_path = file_struct_arr.savefile_froot + file_struct_arr[0].subfolders.data + $
+    file_struct_arr[0].subfolders.bin_1d
   savefiles_1to2d_bin = strarr(n_cubes, n_elements(kperp_density_names), $
     n_elements(wedge_1dbin_names))
   savefiles_2d_masked = strarr(n_cubes, n_elements(kperp_density_names), $
@@ -479,7 +478,7 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
   endif
 
   if plot_types.plot_binning_hist and plot_options.pub eq 1 then begin
-    bin_hist_plot_path = plotfile_path + file_struct_arr(0).subfolders.bin_1d + 'bin_histograms/'
+    bin_hist_plot_path = plotfile_path + file_struct_arr[0].subfolders.bin_1d + 'bin_histograms/'
     if not tag_exist(plot_options, 'plot_filebase') then begin
       plotfile_binning_hist = strarr(n_cubes, n_elements(kperp_density_names), $
         n_elements(wedge_1dbin_names))
@@ -896,7 +895,7 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
       plotfile_base_wt = plotfile_base
     endelse
 
-    plotfile_path_2d = plotfile_path + file_struct_arr(0).subfolders.bin_2d
+    plotfile_path_2d = plotfile_path + file_struct_arr[0].subfolders.bin_2d
     plotfiles_shape = [n_elements(plotfile_base), n_elements(kperp_density_names)]
     plotfiles_err_shape = [n_elements(plotfile_base_wt), n_elements(kperp_density_names)]
     plotfiles_2d = strarr(plotfiles_shape)
@@ -937,7 +936,7 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
     endif else begin
       plotfile_1d_base = plot_options.plot_filebase + uvf_tag
     endelse
-    plotfile_path_1d = plotfile_path + file_struct_arr(0).subfolders.bin_1d
+    plotfile_path_1d = plotfile_path + file_struct_arr[0].subfolders.bin_1d
     begin_1d = plotfile_path_1d + plotfile_1d_base + power_tag + wedge_1dbin_names + fadd_1dbin
     plotfile_1d = begin_1d + '_1dkpower' + plot_options.plot_exten
     plotfile_1d_noise = begin_1d + '_1dnoise' + plot_options.plot_exten
@@ -1047,12 +1046,12 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
 
     if plot_options.pub then begin
 
-      slice_plotfile_base = plotfile_path + file_struct_arr(0).subfolders.slices + $
+      slice_plotfile_base = plotfile_path + file_struct_arr[0].subfolders.slices + $
         plotfile_base + '_' + plot_types.slice_type
       slice_plotfile_end = plot_fadd + plot_options.plot_exten
       if plot_options.individual_plots then begin
 
-        indv_plotfile_base = plotfile_path + file_struct_arr(0).subfolders.slices + $
+        indv_plotfile_base = plotfile_path + file_struct_arr[0].subfolders.slices + $
           transpose([[plotfile_base +'_even_'], [plotfile_base +'_odd_']]) + $
           '_' + plot_types.slice_type
         case plot_types.slice_type of
@@ -1067,7 +1066,7 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
             uv_slice_plotfile = indv_plotfile_base + '_uv_plane' + slice_plotfile_end
           end
           'sumdiff': begin
-            sumdiff_plotfile_base = plotfile_path + file_struct_arr(0).subfolders.slices + $
+            sumdiff_plotfile_base = plotfile_path + file_struct_arr[0].subfolders.slices + $
               [plotfile_base +'_sum_',plotfile_base +'_diff_'] + $
               '_' + plot_types.slice_type
             uf_slice_plotfile = sumdiff_plotfile_base + '_uf_plane' + slice_plotfile_end

--- a/ps_core/ps_power.pro
+++ b/ps_core/ps_power.pro
@@ -377,8 +377,7 @@ pro ps_power, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   min_dist_y_n0 = min(wh_y_n0, min_loc)
   y_slice_ind = wh_y_n0[min_loc]
 
-  yslice_savefile = file_struct.savefile_froot + file_struct.savefilebase + $
-    power_tag + '_xz_plane.idlsave'
+  yslice_savefile = file_struct.xz_savefile
   yslice_power = kpower_slice(power_3d, kx_mpc, ky_mpc, kz_mpc, kperp_lambda_conv, $
     delay_params, hubble_param, noise_3d = noise_3d, noise_expval_3d = noise_expval_3d, $
     weights_3d = weights_3d, slice_axis = 1, slice_inds = y_slice_ind, $
@@ -390,8 +389,7 @@ pro ps_power, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   min_dist_x_n0 = min(abs(n_kx/2-wh_x_n0), min_loc)
   x_slice_ind = wh_x_n0[min_loc]
 
-  xslice_savefile = file_struct.savefile_froot + file_struct.savefilebase + $
-    power_tag + '_yz_plane.idlsave'
+  xslice_savefile = file_struct.yz_savefile
   xslice_power = kpower_slice(power_3d, kx_mpc, ky_mpc, kz_mpc, kperp_lambda_conv, $
     delay_params, hubble_param, noise_3d = noise_3d, noise_expval_3d = noise_expval_3d, $
     weights_3d = weights_3d, slice_axis = 0, slice_inds = x_slice_ind, $
@@ -402,8 +400,7 @@ pro ps_power, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   min_dist_z_n0 = min(wh_z_n0, min_loc)
   z_slice_ind = wh_y_n0[min_loc]
 
-  zslice_savefile = file_struct.savefile_froot + file_struct.savefilebase + $
-    power_tag + '_xy_plane.idlsave'
+  zslice_savefile = file_struct.xy_savefile
   zslice_power = kpower_slice(power_3d, kx_mpc, ky_mpc, kz_mpc, kperp_lambda_conv, $
     delay_params, hubble_param, noise_3d = noise_3d, noise_expval_3d = noise_expval_3d, $
     weights_3d = weights_3d, slice_axis = 2, slice_inds = z_slice_ind, $

--- a/ps_core/ps_power.pro
+++ b/ps_core/ps_power.pro
@@ -16,6 +16,7 @@ pro ps_power, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   if n_elements(freq_flags) ne 0 then freq_mask = file_struct.freq_mask
 
   test_powersave = file_valid(file_struct.power_savefile)
+  if not test_powersave then test_powersave = check_old_path(file_struct, 'power_savefile')
 
   if test_powersave eq 1 and n_elements(freq_flags) ne 0 then begin
     old_freq_mask = getvar_savefile(file_struct.power_savefile, 'freq_mask')
@@ -25,6 +26,7 @@ pro ps_power, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   if test_powersave eq 0 or refresh_options.refresh_ps then begin
 
     test_kcube = file_valid(file_struct.kcube_savefile)
+    if not test_kcube then test_kcube = check_old_path(file_struct, 'kcube_savefile')
 
     if test_kcube eq 1 and n_elements(freq_flags) ne 0 then begin
       old_freq_mask = getvar_savefile(file_struct.kcube_savefile, 'freq_mask')

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -1111,7 +1111,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
   uvf_slice_path = uvf_path + subfolders.slices
 
   ;; file for saving ra/decs of pixels & their DFT values
-  radec_file = uvf_path + subfolders.data + metadata_struct.general_filebase + $
+  radec_file = uvf_path + metadata_struct.general_filebase + $
     '_radec.idlsave'
 
   uvf_savefile = uvf_path + uvf_savefilebase + '_uvf.idlsave'

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -2,7 +2,8 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     variancefile = variancefile, beamfile = beamfile, pixelfile = pixelfile, $
     dirtyvar = dirtyvar, modelvar = modelvar, weightvar = weightvar, $
     variancevar = variancevar, beamvar = beamvar, pixelvar = pixelvar, $
-    freq_ch_range = freq_ch_range, freq_flags = freq_flags, freq_flag_name = freq_flag_name, $
+    freq_ch_range = freq_ch_range, freq_flags = freq_flags, $
+    freq_flag_name = freq_flag_name, $
     save_path = save_path, weight_savefilebase = weight_savefilebase_in, $
     uvf_savefilebase = uvf_savefilebase_in, savefilebase = savefilebase_in, $
     uvf_input = uvf_input, sim = sim, refresh_info = refresh_info, $
@@ -16,8 +17,11 @@ function fhd_file_setup, filename, weightfile = weightfile, $
 
     restore, info_file
 
-    if n_elements(save_path) ne 0 then froot = save_path $
-    else info_filebase = cgRootName(info_file, directory=froot)
+    if n_elements(save_path) ne 0 then begin
+      froot = save_path
+    endif else begin
+      info_filebase = cgRootName(info_file, directory=froot)
+    endelse
 
     if not tag_exist(metadata_struct, 'nfiles') then begin
       print, 'Info file is very old, creating a new one.'
@@ -25,8 +29,11 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     endif
 
     if keyword_set(refresh_info) then begin
-      if n_elements(metadata_struct) gt 0 then datafile = metadata_struct.datafile $
-      else datafile = file_struct_arr[0].datafile
+      if n_elements(metadata_struct) gt 0 then begin
+        datafile = metadata_struct.datafile
+      endif else begin
+        datafile = file_struct_arr[0].datafile
+      endelse
 
       datafile_test = file_test(datafile)
       if min(datafile_test) eq 0 then begin
@@ -37,11 +44,16 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         endif
 
         if min(datafile_test) eq 0 then begin
-          datafile_test = file_test(file_dirname(info_file, /mark_directory) + file_basename(datafile))
-          if min(datafile_test) gt 0 then datafile = file_dirname(info_file, /mark_directory) + file_basename(datafile)
+          datafile_test = file_test(file_dirname(info_file, /mark_directory) + $
+            file_basename(datafile))
+          if min(datafile_test) gt 0 then begin
+            datafile = file_dirname(info_file, /mark_directory) + file_basename(datafile)
+          endif
         endif
 
-        if min(datafile_test) eq 0 then message, 'refresh_info is set but datafile cannot be found'
+        if min(datafile_test) eq 0 then begin
+          message, 'refresh_info is set but datafile cannot be found'
+        endif
       endif
 
     endif
@@ -54,23 +66,30 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     pol_exist = stregex(datafile, '[xy][xy]', /boolean, /fold_case)
     if max(pol_exist) gt 0 then begin
       wh_pol_exist = where(pol_exist gt 0, count_pol_exist, ncomplement = count_no_pol)
-      if count_no_pol gt 0 then message, 'some datafiles have pol identifiers and some do not'
-
+      if count_no_pol gt 0 then begin
+        message, 'some datafiles have pol identifiers and some do not'
+      endif
       pols = strlowcase(stregex(datafile, '[xy][xy]', /extract, /fold_case))
       if n_elements(weightfile) gt 0 then begin
         wt_pols = strlowcase(stregex(weightfile, '[xy][xy]', /extract, /fold_case))
         match, pols, wt_pols, suba, subb, count = count_pol_match
-        if count_pol_match ne n_elements(pols) then message, 'weightfile polarizations must match datafile polarizations'
+        if count_pol_match ne n_elements(pols) then begin
+          message, 'weightfile polarizations must match datafile polarizations'
+        endif
       endif
       if n_elements(variancefile) gt 0 then begin
         var_pols = strlowcase(stregex(variancefile, '[xy][xy]', /extract, /fold_case))
         match, pols, var_pols, suba, subb, count = count_pol_match
-        if count_pol_match ne n_elements(pols) then message, 'variancefile polarizations must match datafile polarizations'
+        if count_pol_match ne n_elements(pols) then begin
+          message, 'variancefile polarizations must match datafile polarizations'
+        endif
       endif
       if n_elements(beamfile) gt 0 then begin
         bm_pols = strlowcase(stregex(beamfile, '[xy][xy]', /extract, /fold_case))
         match, pols, bm_pols, suba, subb, count = count_pol_match
-        if count_pol_match ne n_elements(pols) then message, 'beamfile polarizations must match datafile polarizations'
+        if count_pol_match ne n_elements(pols) then begin
+          message, 'beamfile polarizations must match datafile polarizations'
+        endif
       endif
 
       pol_inc = pols[0]
@@ -85,20 +104,42 @@ function fhd_file_setup, filename, weightfile = weightfile, $
 
       npol = n_elements(pol_inc)
       nfiles = ceil(n_elements(datafile)/float(npol))
-      if nfiles gt 2 then message, 'Only 1 or 2 datafiles supported per pol'
-      if n_elements(datafile) ne npol*nfiles then message, 'The same number of files must be included per pol'
+      if nfiles gt 2 then begin
+        message, 'Only 1 or 2 datafiles supported per pol'
+      endif
+      if n_elements(datafile) ne npol*nfiles then begin
+        message, 'The same number of files must be included per pol'
+      endif
       temp = strarr(npol, nfiles)
       temp_wt = strarr(npol, nfiles)
       temp_var = strarr(npol, nfiles)
       temp_bm = strarr(npol, nfiles)
       for i=0, npol-1 do begin
         wh_pol =  where(pol_num eq i, count_pol)
-        if count_pol ne nfiles then message, 'The same number of files must be included per pol'
+        if count_pol ne nfiles then begin
+          message, 'The same number of files must be included per pol'
+        endif
         temp[i,*] = datafile[wh_pol]
-        if n_elements(weightfile) gt 0 then temp_wt[i,*] = weightfile[wh_pol] else temp_wt = temp
-        if n_elements(variancefile) gt 0 then temp_var[i,*] = variancefile[wh_pol] else temp_var = temp
-        if n_elements(beamfile) gt 0 then temp_bm[i,*] = beamfile[wh_pol] else temp_bm = temp
-        if n_elements(pixelfile) gt 0 then temp_pix[i,*] = pixelfile[wh_pol] else temp_pix = temp
+        if n_elements(weightfile) gt 0 then begin
+          temp_wt[i,*] = weightfile[wh_pol]
+        endif else begin
+          temp_wt = temp
+        endelse
+        if n_elements(variancefile) gt 0 then begin
+          temp_var[i,*] = variancefile[wh_pol]
+        endif else begin
+          temp_var = temp
+        endelse
+        if n_elements(beamfile) gt 0 then begin
+          temp_bm[i,*] = beamfile[wh_pol]
+        endif else begin
+          temp_bm = temp
+        endelse
+        if n_elements(pixelfile) gt 0 then begin
+          temp_pix[i,*] = pixelfile[wh_pol]
+        endif else begin
+          temp_pix = temp
+        endelse
       endfor
       datafile = temporary(temp)
       weightfile = temporary(temp_wt)
@@ -113,7 +154,9 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       pol_num = intarr(npol)
       for i=0, npol-1 do begin
         wh = where(pol_enum eq pol_inc[i], count)
-        if count eq 0 then message, 'pol ' + pol_inc[i] + ' not recognized.'
+        if count eq 0 then begin
+          message, 'pol ' + pol_inc[i] + ' not recognized.'
+        endif
         pol_num[i] = wh[0]
       endfor
       pol_inc = pol_enum[pol_num[uniq(pol_num, sort(pol_num))]]
@@ -129,9 +172,15 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       endif
 
 
-      if n_elements(weightfile) gt 0 then if n_elements(weightfile) ne nfiles then message, 'weightfile must have the same number of elements as datafile'
-      if n_elements(variancefile) gt 0 then  if n_elements(variancefile) ne nfiles then message, 'variancefile must have the same number of elements as datafile'
-      if n_elements(beamfile) gt 0 then if n_elements(beamfile) ne nfiles then message, 'beamfile must have the same number of elements as datafile'
+      if n_elements(weightfile) gt 0 and n_elements(weightfile) ne nfiles then begin
+        message, 'weightfile must have the same number of elements as datafile'
+      endif
+      if n_elements(variancefile) gt 0 and n_elements(variancefile) ne nfiles then begin
+        message, 'variancefile must have the same number of elements as datafile'
+      endif
+      if n_elements(beamfile) gt 0 and n_elements(beamfile) ne nfiles then begin
+        message, 'beamfile must have the same number of elements as datafile'
+      endif
 
       temp = strarr(npol, nfiles)
       temp_wt = strarr(npol, nfiles)
@@ -139,10 +188,26 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       temp_bm = strarr(npol, nfiles)
       for i=0, nfiles-1 do begin
         temp[*,i] = datafile[i]
-        if n_elements(weightfile) gt 0 then temp_wt[*,i] = weightfile[i] else temp_wt = temp
-        if n_elements(variancefile) gt 0 then temp_var[*,i] = variancefile[i] else temp_var = temp
-        if n_elements(beamfile) gt 0 then temp_bm[*,i] = beamfile[i] else temp_bm = temp
-        if n_elements(pixelfile) gt 0 then temp_pix[*,i] = pixelfile[i] else temp_pix = temp
+        if n_elements(weightfile) gt 0 then begin
+          temp_wt[*,i] = weightfile[i]
+        endif else begin
+          temp_wt = temp
+        endelse
+        if n_elements(variancefile) gt 0 then begin
+          temp_var[*,i] = variancefile[i]
+        endif else begin
+          temp_var = temp
+        endelse
+        if n_elements(beamfile) gt 0 then begin
+          temp_bm[*,i] = beamfile[i]
+        endif else begin
+          temp_bm = temp
+        endelse
+        if n_elements(pixelfile) gt 0 then begin
+          temp_pix[*,i] = pixelfile[i]
+        endif else begin
+          temp_pix = temp
+        endelse
       endfor
       datafile = temp
       weightfile = temporary(temp_wt)
@@ -157,15 +222,24 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       data_filebase = [cgRootName(datafile[0,0]), cgRootName(datafile[0,1])]
 
       ;; make this general to all pols
-      if max(pol_exist) gt 0 then for i=0, 1 do data_filebase[i] = strjoin(strsplit(data_filebase[i], '_?[xy][xy]_?', /regex, /extract), '_')
+      if max(pol_exist) gt 0 then begin
+        for i=0, 1 do begin
+          data_filebase[i] = strjoin(strsplit(data_filebase[i], '_?[xy][xy]_?', $
+            /regex, /extract), '_')
+        endfor
+      endif
 
       fileparts_1 = strsplit(data_filebase[0], '_', /extract)
       fileparts_2 = strsplit(data_filebase[1], '_', /extract)
       match_test = strcmp(fileparts_1, fileparts_2)
-      wh_diff = where(match_test eq 0, count_diff, complement = wh_same, ncomplement = count_same)
+      wh_diff = where(match_test eq 0, count_diff, complement = wh_same, $
+        ncomplement = count_same)
 
-      if count_diff gt 0 then infile_label = [strjoin(fileparts_1[wh_diff]), strjoin(fileparts_2[wh_diff])] $
-      else infile_label = strarr(2)
+      if count_diff gt 0 then begin
+        infile_label = [strjoin(fileparts_1[wh_diff]), strjoin(fileparts_2[wh_diff])]
+      endif else begin
+        infile_label = strarr(2)
+      endelse
     endelse
 
     if n_elements(savefilebase_in) eq 0 then begin
@@ -173,22 +247,34 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         data_filebase = cgRootName(datafile[0], directory=datafile_dir)
 
         ;; make this general to all pols
-        if max(pol_exist) gt 0 then data_filebase= strjoin(strsplit(data_filebase, '_?[xy][xy]_?', /regex, /extract), '_')
+        if max(pol_exist) gt 0 then begin
+          data_filebase= strjoin(strsplit(data_filebase, '_?[xy][xy]_?', $
+            /regex, /extract), '_')
+        endif
 
-        if n_elements(save_path) ne 0 then froot = save_path $
-        else froot = datafile_dir
+        if n_elements(save_path) ne 0 then begin
+          froot = save_path
+        endif else begin
+          froot = datafile_dir
+        endelse
         uvf_froot = froot
 
         general_filebase = data_filebase
 
       endif else begin
-        if n_elements(save_path) ne 0 then froot = save_path $
-        else temp = cgRootName(datafile[0], directory=froot)
+        if n_elements(save_path) ne 0 then begin
+          froot = save_path
+        endif else begin
+          temp = cgRootName(datafile[0], directory=froot)
+        endelse
 
         if count_diff eq 0 then general_filebase = data_filebase[0] + '_joint' else begin
-          if count_same gt 0 then general_filebase = strjoin(fileparts_1[wh_same], '_') + '__' + strjoin(fileparts_1[wh_diff]) $
-            + '_' + strjoin(fileparts_2[wh_diff]) + '_joint' $
-          else general_filebase = data_filebase[0] + data_filebase[1] + '_joint'
+          if count_same gt 0 then begin
+            general_filebase = strjoin(fileparts_1[wh_same], '_') + '__' + $
+              strjoin(fileparts_1[wh_diff]) + '_' + strjoin(fileparts_2[wh_diff]) + '_joint'
+            endif else begin
+              general_filebase = data_filebase[0] + data_filebase[1] + '_joint'
+            endelse
         endelse
 
       endelse
@@ -202,7 +288,8 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     endelse
 
     if not keyword_set(refresh_info) then begin
-      ; check for pre-saved info file. If it exists, restore it and return structure. Otherwise construct structure.
+      ;; check for pre-saved info file. If it exists, restore it and return structure.
+      ;; Otherwise construct structure.
       if keyword_set(uvf_input) then uvf_info_tag = '_uvf' else uvf_info_tag = ''
       info_file = froot + general_filebase + uvf_info_tag + '_info.idlsave'
       info_filetest = file_test(info_file)
@@ -216,7 +303,8 @@ function fhd_file_setup, filename, weightfile = weightfile, $
               variancefile = variancefile, beamfile = beamfile, pixelfile = pixelfile, $
               dirtyvar = dirtyvar, modelvar = modelvar, weightvar = weightvar, $
               variancevar = variancevar, beamvar = beamvar, pixelvar = pixelvar, $
-              freq_ch_range = freq_ch_range, freq_flags = freq_flags, freq_flag_name = freq_flag_name, $
+              freq_ch_range = freq_ch_range, freq_flags = freq_flags, $
+              freq_flag_name = freq_flag_name, $
               save_path = save_path, weight_savefilebase = weight_savefilebase_in, $
               uvf_savefilebase = uvf_savefilebase_in, savefilebase = savefilebase_in, $
               uvf_input = uvf_input, sim = sim, refresh_info = refresh_info, $
@@ -235,26 +323,55 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     if keyword_set(sim) then begin
       if n_elements(modelvar) eq 0 then begin
         if max(strmatch(varnames, 'model*',/fold_case)) then begin
-          if keyword_set(uvf_input) then model_varname = strupcase('model_uv_arr') else $
-            if max(pol_exist) gt 0 then model_varname = strupcase('model_cube') else model_varname = strupcase('model_' + pol_inc + '_cube')
+          if keyword_set(uvf_input) then begin
+            model_varname = strupcase('model_uv_arr')
+          endif else begin
+            if max(pol_exist) gt 0 then begin
+              model_varname = strupcase('model_cube')
+            endif else begin
+              model_varname = strupcase('model_' + pol_inc + '_cube')
+            endelse
+          endelse
         endif else begin
           print, 'No model cubes found, checking for dirty or residual cubes'
           if max(strmatch(varnames, 'dirty*',/fold_case)) then begin
-            if keyword_set(uvf_input) then model_varname = strupcase('dirty_uv_arr') else $
-              if max(pol_exist) gt 0 then model_varname = strupcase('dirty_cube') else model_varname = strupcase('dirty_' + pol_inc + '_cube')
+            if keyword_set(uvf_input) then begin
+              model_varname = strupcase('dirty_uv_arr')
+            endif else begin
+              if max(pol_exist) gt 0 then begin
+                model_varname = strupcase('dirty_cube')
+              endif else begin
+                model_varname = strupcase('dirty_' + pol_inc + '_cube')
+              endelse
+            endelse
           endif else if max(strmatch(varnames, 'res*',/fold_case)) then begin
-            if keyword_set(uvf_input) then model_varname = strupcase('res_uv_arr') else $
-              if max(pol_exist) gt 0 then model_varname = strupcase('res_cube') else model_varname = strupcase('res_' + pol_inc + '_cube')
+            if keyword_set(uvf_input) then begin
+              model_varname = strupcase('res_uv_arr')
+            endif else begin
+              if max(pol_exist) gt 0 then begin
+                model_varname = strupcase('res_cube')
+              endif else begin
+                model_varname = strupcase('res_' + pol_inc + '_cube')
+              endelse
+            endelse
           endif
         endelse
       endif else model_varname = modelvar
 
-      if n_elements(model_varname) ne npol then $
-        if n_elements(model_varname) eq 1 then model_varname = replicate(model_varname, npol) $
-      else message, 'modelvar must be a scalar or have the same number of elements as pol_inc'
+      if n_elements(model_varname) ne npol then begin
+        if n_elements(model_varname) eq 1 then begin
+          model_varname = replicate(model_varname, npol)
+        endif
+      endif else begin
+        message, 'modelvar must be a scalar or have the same number of elements as pol_inc'
+      endelse
 
       type_inc = ['model']
-      if npol gt 1 then cube_varname = transpose(model_varname) else cube_varname = model_varname
+      if npol gt 1 then begin
+        cube_varname = transpose(model_varname)
+      endif else begin
+        cube_varname = model_varname
+      endelse
       ntypes = n_elements(type_inc)
       type_pol_str = strarr(npol, ntypes)
       for i=0, npol-1 do type_pol_str[i, *] = type_inc + '_' + pol_inc[i]
@@ -262,55 +379,112 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       ;; check for the existence of dirty, model, residual cubes
       if max(strmatch(varnames, 'dirty*',/fold_case)) then begin
         if n_elements(dirtyvar) eq 0 then begin
-          if keyword_set(uvf_input) then dirty_varname = strupcase('dirty_uv_arr')  else $
-            if max(pol_exist) gt 0 then dirty_varname = strupcase('dirty_cube') else dirty_varname = strupcase('dirty_' + pol_inc + '_cube')
+          if keyword_set(uvf_input) then begin
+            dirty_varname = strupcase('dirty_uv_arr')
+          endif else begin
+            if max(pol_exist) gt 0 then begin
+              dirty_varname = strupcase('dirty_cube')
+            endif else begin
+              dirty_varname = strupcase('dirty_' + pol_inc + '_cube')
+            endelse
+          endelse
         endif else dirty_varname = dirtyvar
-        if n_elements(dirty_varname) ne npol then $
-          if n_elements(dirty_varname) eq 1 then dirty_varname = replicate(dirty_varname, npol) $
-        else message, 'dirtyvar must be a scalar or have the same number of elements as pol_inc'
+        if n_elements(dirty_varname) ne npol then begin
+          if n_elements(dirty_varname) eq 1 then begin
+            dirty_varname = replicate(dirty_varname, npol)
+          endif
+        endif else begin
+          message, 'dirtyvar must be a scalar or have the same number of elements as pol_inc'
+        endelse
 
         type_inc = ['dirty']
-        if npol gt 1 then cube_varname = transpose(dirty_varname) else cube_varname = dirty_varname
+        if npol gt 1 then begin
+          cube_varname = transpose(dirty_varname)
+        endif else begin
+          cube_varname = dirty_varname
+        endelse
       endif
 
       if max(strmatch(varnames, 'model*',/fold_case)) then begin
         if n_elements(modelvar) eq 0 then begin
-          if keyword_set(uvf_input) then model_varname = strupcase('model_uv_arr') else $
-            if max(pol_exist) gt 0 then model_varname = strupcase('model_cube') else model_varname = strupcase('model_' + pol_inc + '_cube')
+          if keyword_set(uvf_input) then begin
+            model_varname = strupcase('model_uv_arr')
+          endif else begin
+            if max(pol_exist) gt 0 then begin
+              model_varname = strupcase('model_cube')
+            endif else begin
+              model_varname = strupcase('model_' + pol_inc + '_cube')
+            endelse
+          endelse
         endif else model_varname = modelvar
-        if n_elements(model_varname) ne npol then $
-          if n_elements(model_varname) eq 1 then model_varname = replicate(model_varname, npol) $
-        else message, 'modelvar must be a scalar or have the same number of elements as pol_inc'
+        if n_elements(model_varname) ne npol then begin
+          if n_elements(model_varname) eq 1 then begin
+            model_varname = replicate(model_varname, npol)
+          endif
+        endif else begin
+          message, 'modelvar must be a scalar or have the same number of elements as pol_inc'
+        endelse
 
         if n_elements(type_inc) eq 0 then begin
           type_inc = ['model']
-          if npol gt 1 then cube_varname = transpose(model_varname) else cube_varname = model_varname
+          if npol gt 1 then begin
+            cube_varname = transpose(model_varname)
+          endif else begin
+            cube_varname = model_varname
+          endelse
         endif else begin
           type_inc = [type_inc, 'model']
-          if npol gt 1 then cube_varname = [cube_varname,transpose(model_varname)] else cube_varname = [cube_varname, model_varname]
+          if npol gt 1 then begin
+            cube_varname = [cube_varname,transpose(model_varname)]
+          endif else begin
+            cube_varname = [cube_varname, model_varname]
+          endelse
         endelse
       endif
 
       if max(strmatch(varnames, 'res*',/fold_case)) then begin
         if n_elements(residualvar) eq 0 then begin
-          if keyword_set(uvf_input) then residual_varname = strupcase('res_uv_arr') else $
-            if max(pol_exist) gt 0 then residual_varname = strupcase('res_cube') else residual_varname = strupcase('res_' + pol_inc + '_cube')
+          if keyword_set(uvf_input) then begin
+            residual_varname = strupcase('res_uv_arr')
+          endif else begin
+            if max(pol_exist) gt 0 then begin
+              residual_varname = strupcase('res_cube')
+            endif else begin
+              residual_varname = strupcase('res_' + pol_inc + '_cube')
+            endelse
+          endelse
         endif else dirty_varname = residualvar
-        if n_elements(residual_varname) ne npol then $
-          if n_elements(residual_varname) eq 1 then residual_varname = replicate(residual_varname, npol) $
-        else message, 'residualvar must be a scalar or have the same number of elements as pol_inc'
+        if n_elements(residual_varname) ne npol then begin
+          if n_elements(residual_varname) eq 1 then begin
+            residual_varname = replicate(residual_varname, npol)
+          endif
+        endif else begin
+          message, 'residualvar must be a scalar or have the same number of elements as pol_inc'
+        endelse
 
         if n_elements(type_inc) eq 0 then begin
           type_inc = ['res']
-          if npol gt 1 then cube_varname = transpose(residual_varname) else cube_varname = residual_varname
+          if npol gt 1 then begin
+            cube_varname = transpose(residual_varname)
+          endif else begin
+            cube_varname = residual_varname
+          endelse
         endif else begin
           type_inc = [type_inc, 'res']
-          if npol gt 1 then cube_varname = [cube_varname,transpose(residual_varname)] else cube_varname = [cube_varname, residual_varname]
+          if npol gt 1 then begin
+            cube_varname = [cube_varname,transpose(residual_varname)]
+          endif else begin
+            cube_varname = [cube_varname, residual_varname]
+          endelse
         endelse
       endif else if (Max(type_inc EQ 'dirty')<Max(type_inc EQ 'model')) then begin
         ;; residual can be constructed from dirty-model
         type_inc = [type_inc, 'res']
-        if npol gt 1 then cube_varname = [cube_varname,transpose(strarr(npol))] else cube_varname = [cube_varname, '']
+        if npol gt 1 then begin
+          cube_varname = [cube_varname,transpose(strarr(npol))]
+        endif else begin
+          cube_varname = [cube_varname, '']
+        endelse
       endif
       ntypes = n_elements(type_inc)
       type_pol_str = strarr(npol, ntypes)
@@ -318,77 +492,122 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     endelse
 
     if n_elements(weightvar) eq 0 then begin
-      if keyword_set(uvf_input) then weight_varname = strupcase('weights_uv_arr')  else $
-        if max(pol_exist) gt 0 then weight_varname = strupcase('weights_cube') else weight_varname = strupcase('weights_' + pol_inc + '_cube')
+      if keyword_set(uvf_input) then begin
+        weight_varname = strupcase('weights_uv_arr')
+      endif else begin
+        if max(pol_exist) gt 0 then begin
+          weight_varname = strupcase('weights_cube')
+        endif else begin
+          weight_varname = strupcase('weights_' + pol_inc + '_cube')
+        endelse
+      endelse
     endif else weight_varname = weightvar
-    if n_elements(weight_varname) ne npol then $
-      if n_elements(weight_varname) eq 1 then weight_varname = replicate(weight_varname, npol) $
-    else message, 'weightvar must be a scalar or have the same number of elements as pol_inc'
+    if n_elements(weight_varname) ne npol then begin
+      if n_elements(weight_varname) eq 1 then begin
+        weight_varname = replicate(weight_varname, npol)
+      endif
+    endif else begin
+      message, 'weightvar must be a scalar or have the same number of elements as pol_inc'
+    endelse
     if n_elements(variancevar) eq 0 then begin
-      if keyword_set(uvf_input) then variance_varname = strupcase('variance_uv_arr') else $
-        if max(pol_exist) gt 0 then variance_varname = strupcase('variance_cube') else variance_varname = strupcase('variance_' + pol_inc + '_cube')
+      if keyword_set(uvf_input) then begin
+        variance_varname = strupcase('variance_uv_arr')
+      endif else begin
+        if max(pol_exist) gt 0 then begin
+          variance_varname = strupcase('variance_cube')
+        endif else begin
+          variance_varname = strupcase('variance_' + pol_inc + '_cube')
+        endelse
+      endelse
     endif else variance_varname = variancevar
-    if n_elements(variance_varname) ne npol then $
-      if n_elements(variance_varname) eq 1 then variance_varname = replicate(variance_varname, npol) $
-    else message, 'variancevar must be a scalar or have the same number of elements as pol_inc'
+    if n_elements(variance_varname) ne npol then begin
+      if n_elements(variance_varname) eq 1 then begin
+        variance_varname = replicate(variance_varname, npol)
+      endif
+    endif else begin
+      message, 'variancevar must be a scalar or have the same number of elements as pol_inc'
+    endelse
 
     if n_elements(beamvar) eq 0 then begin
       if keyword_set(uvf_input) then begin
-        if max(pol_exist) gt 0 then beam_varname = strupcase('beam2_image') else beam_varname = strupcase('beam2_' + pol_inc + '_image')
+        if max(pol_exist) gt 0 then begin
+          beam_varname = strupcase('beam2_image')
+        endif else begin
+          beam_varname = strupcase('beam2_' + pol_inc + '_image')
+        endelse
       endif else begin
-        if max(pol_exist) gt 0 then beam_varname = strupcase('beam_squared_cube') else beam_varname = strupcase('beam_' + pol_inc + '_cube')
+        if max(pol_exist) gt 0 then begin
+          beam_varname = strupcase('beam_squared_cube')
+        endif else begin
+          beam_varname = strupcase('beam_' + pol_inc + '_cube')
+        endelse
       endelse
     endif else beam_varname = beamvar
-    if n_elements(beam_varname) ne npol then $
-      if n_elements(beam_varname) eq 1 then beam_varname = replicate(beam_varname, npol) $
-    else message, 'beamvar must be a scalar or have the same number of elements as pol_inc'
+    if n_elements(beam_varname) ne npol then begin
+      if n_elements(beam_varname) eq 1 then beam_varname = replicate(beam_varname, npol)
+    endif else begin
+      message, 'beamvar must be a scalar or have the same number of elements as pol_inc'
+    endelse
 
     if n_elements(pixelvar) eq 0 then begin
       pixel_varname = strupcase('hpx_inds')
     endif else pixel_varname = pixelvar
-    if n_elements(pixel_varname) ne npol then $
-      if n_elements(pixel_varname) eq 1 then pixel_varname = replicate(pixel_varname, npol) $
-    else message, 'pixelvar must be a scalar or have the same number of elements as pol_inc'
-
+    if n_elements(pixel_varname) ne npol then begin
+      if n_elements(pixel_varname) eq 1 then pixel_varname = replicate(pixel_varname, npol)
+    endif else begin
+      message, 'pixelvar must be a scalar or have the same number of elements as pol_inc'
+    endelse
 
     if max(pol_exist) gt 1 then begin
       if n_elements(weight_savefilebase_in) gt 0 then begin
-        if n_elements(weight_savefilebase_in) ne nfiles then $
-          message, 'if weight_savefilebase is specified it must have the same number of elements as datafiles'
+        if n_elements(weight_savefilebase_in) ne nfiles then begin
+          message, 'if weight_savefilebase is specified it must have the same ' + $
+            'number of elements as datafiles'
+        endif
 
         pols = stregex(weight_savefilebase_in, '[xy][xy]', /extract, /fold_case)
         temp = strarr(npol, nfiles)
         for i=0, npol-1 do begin
           wh_pol =  where(pols eq pol_inc[i], count_pol)
-          if count_pol ne nfiles then message, 'The same number of weight_savefilebase must be included per pol'
+          if count_pol ne nfiles then begin
+            message, 'The same number of weight_savefilebase must be included per pol'
+          endif
           temp[i,*] = weight_savefilebase_in[wh_pol]
         endfor
         weight_savefilebase_in = temp
       endif
       if n_elements(uvf_savefilebase_in) gt 0 then begin
-        if n_elements(uvf_savefilebase_in) ne nfiles then $
-          message, 'if uvf_savefilebase is specified it must have the same number of elements as datafiles'
+        if n_elements(uvf_savefilebase_in) ne nfiles then begin
+          message, 'if uvf_savefilebase is specified it must have the same ' + $
+            'number of elements as datafiles'
+        endif
 
         pols = stregex(uvf_savefilebase_in, '[xy][xy]', /extract, /fold_case)
         temp = strarr(npol, nfiles)
         for i=0, npol-1 do begin
           wh_pol =  where(pols eq pol_inc[i], count_pol)
-          if count_pol ne nfiles then message, 'The same number of uvf_savefilebase must be included per pol'
+          if count_pol ne nfiles then begin
+            message, 'The same number of uvf_savefilebase must be included per pol'
+          endif
           temp[i,*] = uvf_savefilebase_in[wh_pol]
         endfor
         weight_savefilebase_in = temp
       endif
     endif else begin
       if n_elements(weight_savefilebase_in) gt 0 then begin
-        if n_elements(weight_savefilebase_in) ne nfiles then $
-          message, 'if weight_savefilebase is specified it must have the same number of elements as datafiles'
+        if n_elements(weight_savefilebase_in) ne nfiles then begin
+          message, 'if weight_savefilebase is specified it must have the same ' + $
+            'number of elements as datafiles'
+        endif
         temp = strarr(npol, nfiles)
         for i=0, nfiles-1 do temp[*,i] = weight_savefilebase_in[i]
         weight_savefilebase_in = temp
       endif
       if n_elements(uvf_savefilebase_in) gt 0 then begin
-        if n_elements(uvf_savefilebase_in) ne nfiles then $
-          message, 'if uvf_savefilebase is specified it must have the same number of elements as datafiles'
+        if n_elements(uvf_savefilebase_in) ne nfiles then begin
+          message, 'if uvf_savefilebase is specified it must have the same ' + $
+            'number of elements as datafiles'
+        endif
         temp = strarr(npol, nfiles)
         for i=0, nfiles-1 do temp[*,i] = uvf_savefilebase_in[i]
         uvf_savefilebase_in = temp
@@ -408,16 +627,24 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       for type_i=0, ntypes-1 do begin
         if cube_varname[type_i, pol_i] ne '' then begin
           wh = where(strlowcase(varnames) eq strlowcase(cube_varname[type_i, pol_i]), count)
-          if count eq 0 then message, cube_varname[type_i, pol_i] + ' is not present in datafile (datafile=' + datafile[pol_i, file_i] + ')'
+          if count eq 0 then begin
+            message, cube_varname[type_i, pol_i] + ' is not present in datafile ' + $
+              '(datafile=' + datafile[pol_i, file_i] + ')'
+          endif
 
-          data_size = getvar_savefile(datafile[pol_i, file_i], cube_varname[type_i, pol_i], /return_size)
+          data_size = getvar_savefile(datafile[pol_i, file_i], $
+            cube_varname[type_i, pol_i], /return_size)
 
           if data_size[0] eq 0 then message, 'data cube has no size'
           if data_size[n_elements(data_size)-2] eq 10 then begin
             ;; data is a pointer
             if keyword_set(uvf_input) then begin
-              if data_size[0] ne 2 then message, 'Data are in a pointer array, format unknown'
-              if data_size[1] ne npol then message, 'Data are in a pointer array, format unknown'
+              if data_size[0] ne 2 then begin
+                message, 'Data are in a pointer array, format unknown'
+              endif
+              if data_size[1] ne npol then begin
+                message, 'Data are in a pointer array, format unknown'
+              endif
               data = getvar_savefile(datafile[pol_i, file_i], cube_varname[type_i, pol_i])
               dims2 = size(*data[0], /dimension)
               iter=1
@@ -426,33 +653,51 @@ function fhd_file_setup, filename, weightfile = weightfile, $
                 dims2 = size(*data[iter], /dimension)
                 iter = iter+1
               endwhile
-              if min(dims2) eq 0 then  message, 'data cube is empty (file: ' + datafile[pol_i, file_i] + $
-                ', cube name: ' + cube_varname[type_i, pol_i] + ')'
+              if min(dims2) eq 0 then begin
+                message, 'data cube is empty (file: ' + datafile[pol_i, file_i] + $
+                  ', cube name: ' + cube_varname[type_i, pol_i] + ')'
+              endif
               this_data_dims = [dims2, data_size[2], data_size[1]]
               undefine_fhd, data
-            endif else message, 'Data is in a pointer array, format unknown'
+            endif else begin
+              message, 'Data is in a pointer array, format unknown'
+            endelse
 
           endif else this_data_dims = data_size[1:data_size[0]]
 
-          if type_i eq 0 and j eq 0 then data_dims = this_data_dims else if total(abs(this_data_dims - data_dims)) ne 0 then message, 'data dimensions in files do not match'
+          if type_i eq 0 and j eq 0 then begin
+            data_dims = this_data_dims
+          endif else if total(abs(this_data_dims - data_dims)) ne 0 then begin
+            message, 'data dimensions in files do not match'
+          endif
         endif
       endfor
 
 
       void = getvar_savefile(weightfile[pol_i, file_i], names = wt_varnames)
       void = getvar_savefile(variancefile[pol_i, file_i], names = var_varnames)
-      if n_elements(beamfile) gt 0 then void = getvar_savefile(beamfile[pol_i, file_i], names = bm_varnames)
+      if n_elements(beamfile) gt 0 then begin
+        void = getvar_savefile(beamfile[pol_i, file_i], names = bm_varnames)
+      endif
       wh = where(strlowcase(wt_varnames) eq strlowcase(weight_varname[pol_i]), count)
 
-      if count eq 0 then message, weight_varname[pol_i] + ' is not present in weightfile (weightfile=' + weightfile[pol_i, file_i] + ')'
+      if count eq 0 then begin
+        message, weight_varname[pol_i] + ' is not present in weightfile (weightfile=' + $
+          weightfile[pol_i, file_i] + ')'
+      endif
 
-      wt_size = getvar_savefile(weightfile[pol_i, file_i], weight_varname[pol_i], /return_size)
+      wt_size = getvar_savefile(weightfile[pol_i, file_i], weight_varname[pol_i], $
+        /return_size)
       if wt_size[0] eq 0 then message, 'weight cube has no size'
       if wt_size[n_elements(wt_size)-2] eq 10 then begin
         ;; weights cube is a pointer
         if keyword_set(uvf_input) then begin
-          if wt_size[0] ne 2 then message, 'Weights are in a pointer array, format unknown'
-          if wt_size[1] ne npol then message, 'Weights are in a pointer array, format unknown'
+          if wt_size[0] ne 2 then begin
+            message, 'Weights are in a pointer array, format unknown'
+          endif
+          if wt_size[1] ne npol then begin
+            message, 'Weights are in a pointer array, format unknown'
+          endif
           weights = getvar_savefile(weightfile[pol_i, file_i], weight_varname[pol_i])
           dims2 = size(*weights[0], /dimension)
           iter=1
@@ -463,16 +708,22 @@ function fhd_file_setup, filename, weightfile = weightfile, $
           endwhile
           wt_dims = [dims2, wt_size[2], wt_size[1]]
           undefine_fhd, weights
-        endif else message, 'Weights are in a pointer array, format unknown'
+        endif else begin
+          message, 'Weights are in a pointer array, format unknown'
+        endelse
 
       endif else wt_dims = wt_size[1:wt_size[0]]
 
-      if total(abs(wt_dims - data_dims)) ne 0 then message, 'weight and data dimensions in files do not match'
+      if total(abs(wt_dims - data_dims)) ne 0 then begin
+        message, 'weight and data dimensions in files do not match'
+      endif
 
       wh = where(strlowcase(var_varnames) eq strlowcase(variance_varname[pol_i]), count)
 
       if count eq 0 then begin
-        print, variance_varname[pol_i] + ' is not present in variancefile (variancefile=' + variancefile[pol_i, file_i] + '). Using weights^2 instead of variances'
+        print, variance_varname[pol_i] + ' is not present in variancefile ' + $
+          '(variancefile=' + variancefile[pol_i, file_i] + '). ' + $
+          'Using weights^2 instead of variances'
         no_var = 1
       endif else begin
         no_var = 0
@@ -481,8 +732,12 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         if var_size[n_elements(var_size)-2] eq 10 then begin
           ;; Variance cube is a pointer
           if keyword_set(uvf_input) then begin
-            if var_size[0] ne 2 then message, 'Variance are in a pointer array, format unknown'
-            if var_size[1] ne npol then message, 'Variance are in a pointer array, format unknown'
+            if var_size[0] ne 2 then begin
+              message, 'Variance are in a pointer array, format unknown'
+            endif
+            if var_size[1] ne npol then begin
+              message, 'Variance are in a pointer array, format unknown'
+            endif
             variance = getvar_savefile(variancefile[pol_i, file_i], variance_varname[pol_i])
             dims2 = size(*variance[0], /dimension)
             iter=1
@@ -493,11 +748,15 @@ function fhd_file_setup, filename, weightfile = weightfile, $
             endwhile
             var_dims = [dims2, var_size[2], var_size[1]]
             undefine_fhd, variance
-          endif else message, 'Variance is in a pointer array, format unknown'
+          endif else begin
+            message, 'Variance is in a pointer array, format unknown'
+          endelse
 
         endif else var_dims = var_size[1:var_size[0]]
 
-        if total(abs(var_dims - data_dims)) ne 0 then message, 'variance and data dimensions in files do not match'
+        if total(abs(var_dims - data_dims)) ne 0 then begin
+          message, 'variance and data dimensions in files do not match'
+        endif
       endelse
 
       if n_elements(beamfile) gt 0 then begin
@@ -525,13 +784,16 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         endif
       endif
 
-      if j gt 0 then if (this_healpix eq 1 and healpix eq 0) or (this_healpix eq 0 and healpix eq 1) then $
+      if j gt 0 then if (this_healpix eq 1 and healpix eq 0) or (this_healpix eq 0 and healpix eq 1) then begin
         message, 'One datafile is in healpix and the other is not.'
+      endif
       if this_healpix eq 1 then begin
         if j eq 0 then nside = getvar_savefile(datafile[pol_i, file_i], 'nside') else begin
           nside1 = nside
           nside = getvar_savefile(datafile[pol_i, file_i], 'nside')
-          if nside1 ne nside then message, 'nside parameter does not agree between datafiles'
+          if nside1 ne nside then begin
+            message, 'nside parameter does not agree between datafiles'
+          endif
           undefine, nside1
         endelse
         healpix = 1
@@ -539,15 +801,23 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         void = getvar_savefile(pixelfile[pol_i, file_i], names = pix_varnames)
         wh = where(strlowcase(pix_varnames) eq strlowcase(pixel_varname[pol_i]), count)
 
-        if count eq 0 then message, pixel_varname[pol_i] + ' is not present in pixelfile (pixelfile=' + pixelfile[pol_i, file_i] + ')'
+        if count eq 0 then begin
+          message, pixel_varname[pol_i] + ' is not present in pixelfile (pixelfile=' + $
+            pixelfile[pol_i, file_i] + ')'
+        endif
 
         pix_size = getvar_savefile(pixelfile[pol_i, file_i], pixel_varname[pol_i], /return_size)
         if pix_size[0] gt 0 then pix_dims = pix_size[1:pix_size[0]]
-        if total(abs(pix_dims - data_dims[0])) ne 0 then message, 'Number of Healpix pixels does not match data dimension'
+        if total(abs(pix_dims - data_dims[0])) ne 0 then begin
+          message, 'Number of Healpix pixels does not match data dimension'
+        endif
 
         this_pix_vals = getvar_savefile(pixelfile[pol_i, file_i], pixel_varname[pol_i])
-        if pol_i eq 0 and file_i eq 0 then pix_vals = this_pix_vals else if total(abs(this_pix_vals - pix_vals)) ne 0 then message, 'pixel values in files do not match'
-
+        if pol_i eq 0 and file_i eq 0 then begin
+          pix_vals = this_pix_vals
+        endif else if total(abs(this_pix_vals - pix_vals)) ne 0 then begin
+          message, 'pixel values in files do not match'
+        endif
       endif else healpix = 0
 
       wh_obs = where(strmatch(varnames, 'obs*',/fold_case) gt 0, count_obs)
@@ -563,25 +833,40 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         obs_radec_vals = [[obs_arr.obsra],[obs_arr.obsdec]]
         zen_radec_vals = [[obs_arr.zenra],[obs_arr.zendec]]
 
-        if total(abs(obs_arr.n_freq - obs_arr[0].n_freq)) ne 0 then message, 'inconsistent number of frequencies in obs_arr'
-        if j eq 0 then n_freq = obs_arr[0].n_freq else if obs_arr[0].n_freq ne n_freq then $
+        if total(abs(obs_arr.n_freq - obs_arr[0].n_freq)) ne 0 then begin
+          message, 'inconsistent number of frequencies in obs_arr'
+        endif
+        if j eq 0 then n_freq = obs_arr[0].n_freq else if obs_arr[0].n_freq ne n_freq then begin
           message, 'n_freq does not agree between datafiles'
+        endif
 
-        if total(abs(obs_arr.degpix - obs_arr[0].degpix)) ne 0 then message, 'inconsistent degpix values in obs_arr'
-        if j eq 0 then degpix = obs_arr[0].degpix else if obs_arr[0].degpix ne degpix  then $
+        if total(abs(obs_arr.degpix - obs_arr[0].degpix)) ne 0 then begin
+          message, 'inconsistent degpix values in obs_arr'
+        endif
+        if j eq 0 then degpix = obs_arr[0].degpix else if obs_arr[0].degpix ne degpix  then begin
           message, 'degpix does not agree between datafiles'
+        endif
 
-        if total(abs(obs_arr.kpix - obs_arr[0].kpix)) ne 0 then message, 'inconsistent kpix values in obs_arr'
-        if j eq 0 then kpix = obs_arr[0].kpix else if obs_arr[0].kpix ne kpix then $
+        if total(abs(obs_arr.kpix - obs_arr[0].kpix)) ne 0 then begin
+          message, 'inconsistent kpix values in obs_arr'
+        endif
+        if j eq 0 then kpix = obs_arr[0].kpix else if obs_arr[0].kpix ne kpix then begin
           message, 'kpix does not agree between datafiles'
+        endif
 
-        if total(abs(obs_arr.dimension - obs_arr[0].dimension)) ne 0 then message, 'inconsistent dimension values in obs_arr'
-        if j eq 0 then fhd_dim = obs_arr[0].dimension else if obs_arr[0].dimension ne fhd_dim then $
+        if total(abs(obs_arr.dimension - obs_arr[0].dimension)) ne 0 then begin
+          message, 'inconsistent dimension values in obs_arr'
+        endif
+        if j eq 0 then fhd_dim = obs_arr[0].dimension else if obs_arr[0].dimension ne fhd_dim then begin
           message, 'dimension does not agree between datafiles'
+        endif
 
-        if total(abs(obs_arr.elements - obs_arr[0].elements)) ne 0 then message, 'inconsistent elements values in obs_arr'
-        if j eq 0 then fhd_elem = obs_arr[0].elements else if obs_arr[0].elements ne fhd_elem then $
+        if total(abs(obs_arr.elements - obs_arr[0].elements)) ne 0 then begin
+          message, 'inconsistent elements values in obs_arr'
+        endif
+        if j eq 0 then fhd_elem = obs_arr[0].elements else if obs_arr[0].elements ne fhd_elem then begin
           message, 'elements does not agree between datafiles'
+        endif
 
         if fhd_dim ne fhd_elem then message, 'fhd image is not square in x & y'
         kspan = kpix * fhd_dim
@@ -593,13 +878,19 @@ function fhd_file_setup, filename, weightfile = weightfile, $
           wh_base_info = where(strlowcase(obs_tags) eq 'baseline_info', count_base_info)
           if count_bin gt 0 or count_base_info gt 0 then begin
             freq_vals = dblarr(n_freq, n_obs[pol_i, file_i])
-            if count_bin ne 0 then for i=0, n_obs[pol_i, file_i]-1 do freq_vals[*,i] = (*obs_arr[i].bin).freq $
-            else for i=0, n_obs[pol_i, file_i]-1 do freq_vals[*,i] = (*obs_arr[i].baseline_info).freq
+            if count_bin ne 0 then begin
+              for i=0, n_obs[pol_i, file_i]-1 do freq_vals[*,i] = (*obs_arr[i].bin).freq
+            endif else begin
+              for i=0, n_obs[pol_i, file_i]-1 do freq_vals[*,i] = (*obs_arr[i].baseline_info).freq
+            endelse
           endif else stop
         endelse
-        if total(abs(freq_vals - rebin(freq_vals[*,0], n_freq, n_obs[pol_i, file_i]))) ne 0 then message, 'inconsistent freq values in obs_arr'
-        if j eq 0 then freq = freq_vals[*,0] else if total(abs(freq - freq_vals[*,0])) ne 0 then $
+        if total(abs(freq_vals - rebin(freq_vals[*,0], n_freq, n_obs[pol_i, file_i]))) ne 0 then begin
+          message, 'inconsistent freq values in obs_arr'
+        endif
+        if j eq 0 then freq = freq_vals[*,0] else if total(abs(freq - freq_vals[*,0])) ne 0 then begin
           message, 'frequencies do not agree between datafiles'
+        endif
         freq_resolution = freq[1]-freq[0]
 
         dt_vals = dblarr(n_obs[pol_i, file_i])
@@ -610,14 +901,22 @@ function fhd_file_setup, filename, weightfile = weightfile, $
             ;; only allow time resolutions of n*.5 sec
             dt_vals[i] = round(((times[1]-times[0])*24*3600)*2.)/2.
           endfor
-          if total(abs(dt_vals - dt_vals[0])) ne 0 then message, 'inconsistent time averaging in obs_arr'
+          if total(abs(dt_vals - dt_vals[0])) ne 0 then begin
+            message, 'inconsistent time averaging in obs_arr'
+          endif
         endelse
-        if j eq 0 then time_resolution = dt_vals[0] else $
-          if total(abs(time_resolution - dt_vals[0])) ne 0 then message, 'time averaging does not agree between datafiles'
-
-        theta_vals = angle_difference(obs_radec_vals[*,1], obs_radec_vals[*,0], zen_radec_vals[*,1], zen_radec_vals[*,0], $
-          /degree, /nearest)
-        if j eq 0 then max_theta = max(theta_vals) else max_theta = max([max_theta, theta_vals])
+        if j eq 0 then time_resolution = dt_vals[0] else begin
+          if total(abs(time_resolution - dt_vals[0])) ne 0 then begin
+            message, 'time averaging does not agree between datafiles'
+          endif
+        endelse
+        theta_vals = angle_difference(obs_radec_vals[*,1], obs_radec_vals[*,0], $
+          zen_radec_vals[*,1], zen_radec_vals[*,0], /degree, /nearest)
+        if j eq 0 then begin
+          max_theta = max(theta_vals)
+        endif else begin
+          max_theta = max([max_theta, theta_vals])
+        endelse
 
         if j eq 0 then n_vis = fltarr(npol, nfiles)
         n_vis[pol_i, file_i] = total(obs_arr.n_vis)
@@ -631,23 +930,32 @@ function fhd_file_setup, filename, weightfile = weightfile, $
           beam_int_arr = fltarr([n_obs[pol_i, file_i], n_freq])
           if tag_exist(obs_arr,'primary_beam_sq_area') then begin
             for i=0, n_obs[pol_i, file_i]-1 do begin
-              if obs_arr[i].primary_beam_sq_area(pol_i) eq !Null then beam_int_arr[i, *] = 0 else $
+              if obs_arr[i].primary_beam_sq_area(pol_i) eq !Null then begin
+                beam_int_arr[i, *] = 0
+              endif else begin
                 beam_int_arr[i, *] = *(obs_arr[i].primary_beam_sq_area(pol_i))
+              endelse
             endfor
           endif else begin
             for i=0, n_obs[pol_i, file_i]-1 do begin
-              if obs_arr[i].beam_integral(pol_i) eq !Null then beam_int_arr[i, *] = 0 else $
+              if obs_arr[i].beam_integral(pol_i) eq !Null then begin
+                beam_int_arr[i, *] = 0
+              endif else begin
                 beam_int_arr[i, *] = *(obs_arr[i].beam_integral(pol_i))
+              endelse
             endfor
           endelse
           if max(beam_int_arr) eq 0 then begin
             ;; all the pointers were null -- treat as if it doesn't exist in obs structure
             undefine, beam_int_arr
           endif else begin
-            if min(beam_int_arr) eq 0 then message, 'some beam_integrals are null, others are not.'
+            if min(beam_int_arr) eq 0 then begin
+              message, 'some beam_integrals are null, others are not.'
+            endif
 
             wh_freq_all_0 = where(total(n_vis_freq_arr, 1) eq 0, count_freq_all_0)
-            beam_int[pol_i, file_i, *] = total(beam_int_arr * n_vis_freq_arr, 1)/total(n_vis_freq_arr, 1)
+            beam_int[pol_i, file_i, *] = total(beam_int_arr * n_vis_freq_arr, 1) / $
+              total(n_vis_freq_arr, 1)
             if count_freq_all_0 gt 0 then beam_int[pol_i, file_i, wh_freq_all_0]=0
           endelse
         endif
@@ -659,11 +967,17 @@ function fhd_file_setup, filename, weightfile = weightfile, $
 
           if noise_dims[0] lt npol or noise_dims[1] ne n_freq then begin
             if min(pol_exist) eq 1 and n_elements(*obs_arr[0].vis_noise) eq n_freq then begin
-              for i=0, n_obs[pol_i, file_i]-1 do vis_noise_arr[i, *] = (*obs_arr[i].vis_noise)
-            endif else message, 'vis_noise dimensions do not match npol, n_freq'
+              for i=0, n_obs[pol_i, file_i]-1 do begin
+                vis_noise_arr[i, *] = (*obs_arr[i].vis_noise)
+              endfor
+            endif else begin
+              message, 'vis_noise dimensions do not match npol, n_freq'
+            endelse
           endif else begin
             wh_pol = where(strmatch(obs_arr[0].pol_names, pol_inc[pol_i], /fold_case), count)
-            if count ne 1 then message, 'pol can not be uniquely identified in obs_arr.pol_names'
+            if count ne 1 then begin
+              message, 'pol can not be uniquely identified in obs_arr.pol_names'
+            endif
             for i=0, n_obs[pol_i, file_i]-1 do vis_noise_arr[i, *] = (*obs_arr[i].vis_noise)[wh_pol,*]
           endelse
 
@@ -678,7 +992,9 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         n_vis_freq[pol_i, file_i, *] = total(n_vis_freq_arr, 1)
 
         undefine_fhd, obs_arr
-      endif else message, 'no obs or obs_arr in datafile'
+      endif else begin
+        message, 'no obs or obs_arr in datafile'
+      endelse
 
 
       if healpix then data_nfreq = data_dims[1] else data_nfreq = data_dims[2]
@@ -687,14 +1003,23 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         if j eq 0 then n_avg = getvar_savefile(datafile[pol_i, file_i], 'n_avg') else begin
           n_avg1 = n_avg
           n_avg = getvar_savefile(datafile[pol_i, file_i], 'n_avg')
-          if n_avg1 ne n_avg then message, 'n_avg parameter does not agree between datafiles'
+          if n_avg1 ne n_avg then begin
+            message, 'n_avg parameter does not agree between datafiles'
+          endif
           undefine, n_avg1
         endelse
       endif else begin
-        print, 'no n_avg present, calculate from data frequency length; n_avg = ', n_freq/data_nfreq
-        if j eq 0 then n_avg = n_freq/data_nfreq else if n_avg ne n_freq/data_nfreq then message, 'calculated n_avg does not agree between datafiles'
+        print, 'no n_avg present, calculate from data frequency length; n_avg = ', $
+          n_freq/data_nfreq
+        if j eq 0 then begin
+          n_avg = n_freq/data_nfreq
+        endif else if n_avg ne n_freq/data_nfreq then begin
+          message, 'calculated n_avg does not agree between datafiles'
+        endif
       endelse
-      if n_freq/n_avg ne data_nfreq then message, 'number of frequencies does not match number of data slices'
+      if n_freq/n_avg ne data_nfreq then begin
+        message, 'number of frequencies does not match number of data slices'
+      endif
 
     endfor
 
@@ -717,7 +1042,8 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         inds_arr = indgen(n_freq)
         if n_elements(vis_noise) gt 0 then begin
           inds_use = inds_arr[i*n_avg:i*n_avg+(n_avg-1)]
-          wh_zero = where(total(total(n_vis_freq[*,*,inds_use],2),1) eq 0, count_zero, complement = wh_gt0, ncomplement = count_gt0)
+          wh_zero = where(total(total(n_vis_freq[*,*,inds_use],2),1) eq 0, $
+            count_zero, complement = wh_gt0, ncomplement = count_gt0)
 
           if count_gt0 eq 0 then continue
 
@@ -728,8 +1054,12 @@ function fhd_file_setup, filename, weightfile = weightfile, $
             if n_elements(beam_int) gt 0 then beam_int_avg[*,*,i] = beam_int[*,*,inds_use]
             n_vis_freq_avg[*,*,i] = n_vis_freq[*,*,inds_use]
           endif else begin
-            vis_noise_avg[*,*,i] = sqrt(total(vis_noise[*,*,inds_use]^2.*n_vis_freq[*,*,inds_use], 3)/total(n_vis_freq[*,*,inds_use],3))
-            if n_elements(beam_int) gt 0 then beam_int_avg[*,*,i] = total(beam_int[*,*,inds_use]*n_vis_freq[*,*,inds_use], 3)/total(n_vis_freq[*,*,inds_use],3)
+            vis_noise_avg[*,*,i] = sqrt(total(vis_noise[*,*,inds_use]^2.*n_vis_freq[*,*,inds_use], 3) / $
+              total(n_vis_freq[*,*,inds_use],3))
+            if n_elements(beam_int) gt 0 then begin
+              beam_int_avg[*,*,i] = total(beam_int[*,*,inds_use]*n_vis_freq[*,*,inds_use], 3) / $
+                total(n_vis_freq[*,*,inds_use],3)
+            endif
             n_vis_freq_avg[*,*,i] = total(n_vis_freq[*,*,inds_use], 3)
           endelse
 
@@ -743,22 +1073,36 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       frequencies = freq / 1e6 ;; in MHz
     endelse
 
-    metadata_struct = {datafile: datafile, weightfile: weightfile, variancefile:variancefile, $
-      cube_varname:cube_varname, weight_varname:weight_varname, variance_varname:variance_varname, $
-      frequencies:frequencies, freq_resolution:freq_resolution, time_resolution:time_resolution, $
-      n_vis:n_vis, n_vis_freq:n_vis_freq, max_baseline_lambda:max_baseline_lambda, max_theta:max_theta, degpix:degpix, kpix:kpix, kspan:kspan, $
-      general_filebase:general_filebase, infile_label:infile_label, type_pol_str:type_pol_str, type_inc:type_inc, n_obs:n_obs, pol_inc:pol_inc, nfiles:nfiles}
+    metadata_struct = {datafile: datafile, weightfile: weightfile, $
+      variancefile:variancefile, cube_varname:cube_varname, $
+      weight_varname:weight_varname, variance_varname:variance_varname, $
+      frequencies:frequencies, freq_resolution:freq_resolution, $
+      time_resolution:time_resolution, $
+      n_vis:n_vis, n_vis_freq:n_vis_freq, max_baseline_lambda:max_baseline_lambda, $
+      max_theta:max_theta, degpix:degpix, kpix:kpix, kspan:kspan, $
+      general_filebase:general_filebase, infile_label:infile_label, $
+      type_pol_str:type_pol_str, type_inc:type_inc, n_obs:n_obs, pol_inc:pol_inc, $
+      nfiles:nfiles}
 
-    if n_elements(beamfile) gt 0 then metadata_struct = create_struct(metadata_struct, 'beamfile', beamfile, 'beam_varname', beam_varname)
+    if n_elements(beamfile) gt 0 then begin
+      metadata_struct = create_struct(metadata_struct, 'beamfile', beamfile, $
+        'beam_varname', beam_varname)
+    endif
 
-
-    if healpix then metadata_struct = create_struct(metadata_struct, 'pixelfile', pixelfile, 'pixel_varname', pixel_varname, 'nside', nside)
+    if healpix then begin
+      metadata_struct = create_struct(metadata_struct, 'pixelfile', pixelfile, $
+        'pixel_varname', pixel_varname, 'nside', nside)
+    endif
 
     if no_var then metadata_struct = create_struct(metadata_struct, 'no_var', 1)
 
-    if n_elements(vis_noise) gt 0 then metadata_struct = create_struct(metadata_struct, 'vis_noise', vis_noise)
+    if n_elements(vis_noise) gt 0 then begin
+      metadata_struct = create_struct(metadata_struct, 'vis_noise', vis_noise)
+    endif
 
-    if n_elements(beam_int) gt 0 then metadata_struct = create_struct(metadata_struct, 'beam_int', beam_int)
+    if n_elements(beam_int) gt 0 then begin
+      metadata_struct = create_struct(metadata_struct, 'beam_int', beam_int)
+    endif
 
     save, filename = info_file, metadata_struct
   endif
@@ -791,7 +1135,10 @@ function fhd_file_setup, filename, weightfile = weightfile, $
 
   wt_file_label = '_weights_' + strlowcase(metadata_struct.pol_inc)
   file_label = strarr(npol, ntypes)
-  for i=0, npol-1 do file_label[i,*] = '_' + strlowcase(metadata_struct.type_inc) + '_' + strlowcase(metadata_struct.pol_inc[i])
+  for i=0, npol-1 do begin
+    file_label[i,*] = '_' + strlowcase(metadata_struct.type_inc) + '_' + $
+      strlowcase(metadata_struct.pol_inc[i])
+  endfor
   savefilebase = metadata_struct.general_filebase + file_tags.uvf_tag + file_label
 
   if n_elements(uvf_savefilebase_in) lt nfiles then begin
@@ -800,8 +1147,13 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       ;; test datafile path to see if it exists. if not, use froot
       for pol_i=0, npol-1 do begin
         for file_i=0, nfiles-1 do begin
-          datafile_path = file_dirname(metadata_struct.datafile[pol_i, file_i], /mark_directory)
-          if file_test(datafile_path, /directory) then uvf_froot[pol_i, file_i, *] = datafile_path else uvf_froot[pol_i, file_i, *] = froot
+          datafile_path = file_dirname(metadata_struct.datafile[pol_i, file_i], $
+            /mark_directory)
+          if file_test(datafile_path, /directory) then begin
+            uvf_froot[pol_i, file_i, *] = datafile_path
+          endif else begin
+            uvf_froot[pol_i, file_i, *] = froot
+          endelse
         endfor
       endfor
     endelse
@@ -809,9 +1161,15 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     uvf_label = strarr(npol, nfiles, ntypes)
     for pol_i=0, npol-1 do begin
       for file_i=0, nfiles-1 do begin
-        if max(pol_exist) eq 1 then uvf_savefilebase[pol_i, file_i,*] = cgRootName(metadata_struct.datafile[pol_i, file_i]) + file_tags.uvf_tag + '_' + metadata_struct.type_inc $
-        else uvf_savefilebase[pol_i, file_i,*] = cgRootName(metadata_struct.datafile[pol_i, file_i]) + file_tags.uvf_tag + file_label[pol_i, *]
-        uvf_label[pol_i, file_i,*] = metadata_struct.infile_label[file_i] + '_' + file_label[pol_i, *]
+        if max(pol_exist) eq 1 then begin
+          uvf_savefilebase[pol_i, file_i,*] = cgRootName(metadata_struct.datafile[pol_i, file_i]) + $
+            file_tags.uvf_tag + '_' + metadata_struct.type_inc
+          endif else begin
+            uvf_savefilebase[pol_i, file_i,*] = cgRootName(metadata_struct.datafile[pol_i, file_i]) + $
+              file_tags.uvf_tag + file_label[pol_i, *]
+          endelse
+        uvf_label[pol_i, file_i,*] = metadata_struct.infile_label[file_i] + '_' + $
+          file_label[pol_i, *]
       endfor
     endfor
   endif else begin
@@ -822,7 +1180,11 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         for file_i=0, nfiles-1 do begin
           if temp[i] ne '.' then uvf_froot[i,*] = temp[i] else begin
             datafile_path = file_dirname(metadata_struct.datafile[pol_i, file_i], /mark_directory)
-            if file_test(datafile_path, /directory) then uvf_froot[pol_i, file_i, *] = datafile_path else uvf_froot[pol_i, file_i, *] = froot
+            if file_test(datafile_path, /directory) then begin
+              uvf_froot[pol_i, file_i, *] = datafile_path
+            endif else begin
+              uvf_froot[pol_i, file_i, *] = froot
+            endelse
           endelse
         endfor
       endfor
@@ -870,7 +1232,11 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       for pol_i=0, npol-1 do begin
         for file_i=0, nfiles-1 do begin
           wtfile_path = file_dirname(metadata_struct.weightfile[pol_i, file_i], /mark_directory)
-          if file_test(wtfile_path, /directory) then wt_froot[pol_i, file_i] = wtfile_path else wt_froot[pol_i, file_i] = froot
+          if file_test(wtfile_path, /directory) then begin
+            wt_froot[pol_i, file_i] = wtfile_path
+          endif else begin
+            wt_froot[pol_i, file_i] = froot
+          endelse
         endfor
       endfor
     endelse
@@ -878,8 +1244,13 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     weight_savefilebase = strarr(npol, nfiles)
     for pol_i=0, npol-1 do begin
       for file_i=0, nfiles-1 do begin
-        if max(pol_exist) eq 1 then weight_savefilebase[pol_i, file_i] = cgRootName(metadata_struct.weightfile[pol_i, file_i]) + file_tags.uvf_tag + '_weights' $
-        else weight_savefilebase[pol_i, file_i] = cgRootName(metadata_struct.weightfile[pol_i, file_i]) + file_tags.uvf_tag + wt_file_label[pol_i]
+        if max(pol_exist) eq 1 then begin
+          weight_savefilebase[pol_i, file_i] = cgRootName(metadata_struct.weightfile[pol_i, file_i]) + $
+            file_tags.uvf_tag + '_weights'
+          endif else begin
+            weight_savefilebase[pol_i, file_i] = cgRootName(metadata_struct.weightfile[pol_i, file_i]) + $
+              file_tags.uvf_tag + wt_file_label[pol_i]
+          endelse
       endfor
     endfor
 
@@ -890,9 +1261,15 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       wt_froot = strarr(npol, nfiles)
       for pol_i=0, npol-1 do begin
         for file_i=0, nfiles-1 do begin
-          if temp[pol_i, file_i] ne '.' then wt_froot[pol_i, file_i] = temp[pol_i, file_i] else begin
+          if temp[pol_i, file_i] ne '.' then begin
+            wt_froot[pol_i, file_i] = temp[pol_i, file_i]
+          endif else begin
             wtfile_path = file_dirname(metadata_struct.weightfile[pol_i, file_i], /mark_directory)
-            if file_test(wtfile_path, /directory) then wt_froot[pol_i, file_i] = wtfile_path else wt_froot[pol_i, file_i] = froot
+            if file_test(wtfile_path, /directory) then begin
+              wt_froot[pol_i, file_i] = wtfile_path
+            endif else begin
+              wt_froot[pol_i, file_i] = froot
+            endelse
           endelse
         endfor
       endfor
@@ -908,7 +1285,11 @@ function fhd_file_setup, filename, weightfile = weightfile, $
   for pol_i=0, npol-1 do begin
     for type_i=0, ntypes-1 do begin
 
-      if ntypes gt 1 then data_varname = metadata_struct.cube_varname[type_i, pol_i] else data_varname = metadata_struct.cube_varname[pol_i]
+      if ntypes gt 1 then begin
+        data_varname = metadata_struct.cube_varname[type_i, pol_i]
+      endif else begin
+        data_varname = metadata_struct.cube_varname[pol_i]
+      endelse
       if data_varname ne '' then begin
         derived_uvf_inputfiles = strarr(nfiles,2)
         derived_uvf_varname = strarr(nfiles,2)
@@ -921,34 +1302,57 @@ function fhd_file_setup, filename, weightfile = weightfile, $
           derived_uvf_varname = strarr(nfiles,2)
           for j=0, nfiles-1 do begin
             derived_uvf_inputfiles[j,*] = metadata_struct.datafile[pol_i, j]
-            derived_uvf_varname[j,*] = [metadata_struct.cube_varname[0, pol_i], metadata_struct.cube_varname[1, pol_i]]
+            derived_uvf_varname[j,*] = [metadata_struct.cube_varname[0, pol_i], $
+              metadata_struct.cube_varname[1, pol_i]]
           endfor
         endelse
       endelse
 
-      file_struct = {datafile:reform(metadata_struct.datafile[pol_i,*]), weightfile:reform(metadata_struct.weightfile[pol_i,*]), $
+      file_struct = {datafile:reform(metadata_struct.datafile[pol_i,*]), $
+        weightfile:reform(metadata_struct.weightfile[pol_i,*]), $
         variancefile:reform(metadata_struct.variancefile[pol_i,*]), $
         datavar:data_varname, weightvar:metadata_struct.weight_varname[pol_i], $
         variancevar:metadata_struct.variance_varname[pol_i], $
-        frequencies:metadata_struct.frequencies, freq_resolution:metadata_struct.freq_resolution, time_resolution:metadata_struct.time_resolution, $
-        n_obs:reform(metadata_struct.n_obs[pol_i,*]), n_vis:reform(metadata_struct.n_vis[pol_i,*]), n_vis_freq:reform(metadata_struct.n_vis_freq[pol_i,*,*]), $
-        max_baseline_lambda:metadata_struct.max_baseline_lambda, max_theta:metadata_struct.max_theta, $
-        degpix:metadata_struct.degpix, kpix:metadata_struct.kpix, kspan:metadata_struct.kspan, $
-        uf_savefile:reform(uf_savefile[pol_i,*,type_i]), vf_savefile:reform(vf_savefile[pol_i,*,type_i]), uv_savefile:reform(uv_savefile[pol_i,*,type_i]), $
-        uf_raw_savefile:reform(uf_raw_savefile[pol_i,*,type_i]), vf_raw_savefile:reform(vf_raw_savefile[pol_i,*,type_i]), $
+        frequencies:metadata_struct.frequencies, $
+        freq_resolution:metadata_struct.freq_resolution, $
+        time_resolution:metadata_struct.time_resolution, $
+        n_obs:reform(metadata_struct.n_obs[pol_i,*]), $
+        n_vis:reform(metadata_struct.n_vis[pol_i,*]), $
+        n_vis_freq:reform(metadata_struct.n_vis_freq[pol_i,*,*]), $
+        max_baseline_lambda:metadata_struct.max_baseline_lambda, $
+        max_theta:metadata_struct.max_theta, degpix:metadata_struct.degpix, $
+        kpix:metadata_struct.kpix, kspan:metadata_struct.kspan, $
+        uf_savefile:reform(uf_savefile[pol_i,*,type_i]), $
+        vf_savefile:reform(vf_savefile[pol_i,*,type_i]), $
+        uv_savefile:reform(uv_savefile[pol_i,*,type_i]), $
+        uf_raw_savefile:reform(uf_raw_savefile[pol_i,*,type_i]), $
+        vf_raw_savefile:reform(vf_raw_savefile[pol_i,*,type_i]), $
         uv_raw_savefile:reform(uv_raw_savefile[pol_i,*,type_i]), $
-        uf_sum_savefile:uf_sum_savefile[pol_i, type_i], vf_sum_savefile:vf_sum_savefile[pol_i,type_i], $
-        uv_sum_savefile:uv_sum_savefile[pol_i,type_i], uf_diff_savefile:uf_diff_savefile[pol_i,type_i], $
-        vf_diff_savefile:vf_diff_savefile[pol_i,type_i], uv_diff_savefile:uv_diff_savefile[pol_i,type_i], $
-        uf_weight_savefile:reform(uf_weight_savefile[pol_i, *]), vf_weight_savefile:reform(vf_weight_savefile[pol_i, *]), $
+        uf_sum_savefile:uf_sum_savefile[pol_i, type_i], $
+        vf_sum_savefile:vf_sum_savefile[pol_i,type_i], $
+        uv_sum_savefile:uv_sum_savefile[pol_i,type_i], $
+        uf_diff_savefile:uf_diff_savefile[pol_i,type_i], $
+        vf_diff_savefile:vf_diff_savefile[pol_i,type_i], $
+        uv_diff_savefile:uv_diff_savefile[pol_i,type_i], $
+        uf_weight_savefile:reform(uf_weight_savefile[pol_i, *]), $
+        vf_weight_savefile:reform(vf_weight_savefile[pol_i, *]), $
         uv_weight_savefile:reform(uv_weight_savefile[pol_i, *]), $
-        kcube_savefile:kcube_savefile[pol_i,type_i], power_savefile:power_savefile[pol_i,type_i], fits_power_savefile:fits_power_savefile[pol_i,type_i],$
-        savefile_froot:froot, savefilebase:savefilebase[pol_i,type_i], general_filebase:general_filebase, $
+        kcube_savefile:kcube_savefile[pol_i,type_i], $
+        power_savefile:power_savefile[pol_i,type_i], $
+        fits_power_savefile:fits_power_savefile[pol_i,type_i],$
+        savefile_froot:froot, savefilebase:savefilebase[pol_i,type_i], $
+        general_filebase:general_filebase, $
         weight_savefilebase:reform(weight_savefilebase[pol_i, *]), $
-        derived_uvf_inputfiles:derived_uvf_inputfiles, derived_uvf_varname:derived_uvf_varname, $
-        file_label:file_label[pol_i,type_i], uvf_label:reform(uvf_label[pol_i,*,type_i]), wt_file_label:wt_file_label[pol_i], $
-        uvf_tag:file_tags.uvf_tag, kcube_tag:file_tags.kcube_tag, power_tag:file_tags.power_tag, type_pol_str:metadata_struct.type_pol_str[pol_i,type_i], $
-        pol_index:pol_i, type_index:type_i, pol:metadata_struct.pol_inc[pol_i], type:metadata_struct.type_inc[type_i], nfiles:nfiles}
+        derived_uvf_inputfiles:derived_uvf_inputfiles, $
+        derived_uvf_varname:derived_uvf_varname, $
+        file_label:file_label[pol_i,type_i], $
+        uvf_label:reform(uvf_label[pol_i,*,type_i]), $
+        wt_file_label:wt_file_label[pol_i], $
+        uvf_tag:file_tags.uvf_tag, kcube_tag:file_tags.kcube_tag, $
+        power_tag:file_tags.power_tag, $
+        type_pol_str:metadata_struct.type_pol_str[pol_i,type_i], $
+        pol_index:pol_i, type_index:type_i, pol:metadata_struct.pol_inc[pol_i], $
+        type:metadata_struct.type_inc[type_i], nfiles:nfiles}
 
       if tag_exist(metadata_struct, 'beamfile') then begin
         file_struct = create_struct(file_struct, 'beamfile', reform(metadata_struct.beamfile[pol_i,*]), $
@@ -962,19 +1366,29 @@ function fhd_file_setup, filename, weightfile = weightfile, $
           'uvf_weight_savefile', uvf_weight_savefile[pol_i,*])
       endif
 
-      if healpix then file_struct = create_struct(file_struct, 'pixelfile', metadata_struct.pixelfile[pol_i,*], 'pixelvar', $
+      if healpix then file_struct = create_struct(file_struct, 'pixelfile', $
+        metadata_struct.pixelfile[pol_i,*], 'pixelvar', $
         metadata_struct.pixel_varname[pol_i,*], 'nside', metadata_struct.nside)
 
       if no_var then file_struct = create_struct(file_struct, 'no_var', 1)
 
-      if n_elements(freq_mask) gt 0 then file_struct = create_struct(file_struct, 'freq_mask', freq_mask)
+      if n_elements(freq_mask) gt 0 then begin
+        file_struct = create_struct(file_struct, 'freq_mask', freq_mask)
+      endif
 
-      if tag_exist(metadata_struct, 'vis_noise') gt 0 then file_struct = create_struct(file_struct, 'vis_noise', reform(metadata_struct.vis_noise[pol_i,*,*]))
+      if tag_exist(metadata_struct, 'vis_noise') gt 0 then begin
+        file_struct = create_struct(file_struct, 'vis_noise', reform(metadata_struct.vis_noise[pol_i,*,*]))
+      endif
 
-      if tag_exist(metadata_struct, 'beam_int') then file_struct = create_struct(file_struct, 'beam_int', reform(metadata_struct.beam_int[pol_i,*,*]))
+      if tag_exist(metadata_struct, 'beam_int') then begin
+        file_struct = create_struct(file_struct, 'beam_int', reform(metadata_struct.beam_int[pol_i,*,*]))
+      endif
 
-
-      if pol_i eq 0 and type_i eq 0 then file_struct_arr = replicate(file_struct, ntypes, npol) else file_struct_arr[type_i, pol_i] = file_struct
+      if pol_i eq 0 and type_i eq 0 then begin
+        file_struct_arr = replicate(file_struct, ntypes, npol)
+      endif else begin
+        file_struct_arr[type_i, pol_i] = file_struct
+      endelse
     endfor
   endfor
 

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -768,8 +768,11 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       if count_obs ne 0 then begin
         n_obs[pol_i, file_i] = n_elements(obs_arr)
 
-        if j eq 0 then max_baseline_lambda = max(obs_arr.max_baseline) $
-        else max_baseline_lambda = max([max_baseline_lambda, obs_arr.max_baseline])
+        if j eq 0 then begin
+          max_baseline_lambda = max(obs_arr.max_baseline)
+        endif else begin
+          max_baseline_lambda = max([max_baseline_lambda, obs_arr.max_baseline])
+        endelse
 
         obs_radec_vals = [[obs_arr.obsra],[obs_arr.obsdec]]
         zen_radec_vals = [[obs_arr.zenra],[obs_arr.zendec]]

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -1104,11 +1104,12 @@ function fhd_file_setup, filename, weightfile = weightfile, $
   subfolders = {data: 'data/', plots: 'plots/', uvf: 'uvf_cubes/', beams: 'beam_cubes/', $
     kspace: 'kspace_cubes/', slices: 'slices/', bin_2d: '2d_binning/', bin_1d: '1d_binning/'}
 
-  ;; file for saving ra/decs of pixels
-  radec_file = froot + subfolders.data + metadata_struct.general_filebase + '_radec.idlsave'
-
   uvf_path = froot + subfolders.data + subfolders.uvf
   uvf_slice_path = uvf_path + subfolders.slices
+
+  ;; file for saving ra/decs of pixels & their DFT values
+  radec_file = uvf_path + subfolders.data + metadata_struct.general_filebase + $
+    '_radec.idlsave'
 
   uvf_savefile = uvf_path + uvf_savefilebase + '_uvf.idlsave'
   uf_savefile = uvf_slice_path + uvf_savefilebase + '_uf_plane.idlsave'

--- a/ps_utils/check_old_path.pro
+++ b/ps_utils/check_old_path.pro
@@ -1,0 +1,26 @@
+function check_old_path, file_struct, tag_name, index = index
+
+  tag_loc = where(strlowcase(tag_names(file_struct)) eq strlowcase(tag_name), count_loc)
+  if count_loc eq 0 then begin
+    message, 'tag_name ' + tag_name + ' not found in file_struct'
+  endif
+  tag_loc = tag_loc[0]
+
+  if n_elements(index) gt 0 then begin
+    old_file = file_struct.savefile_froot + file_basename(file_struct.(tag_loc)[index])
+  endif else begin
+    old_file = file_struct.savefile_froot + file_basename(file_struct.(tag_loc))
+  endelse
+
+  test_uvf_old = file_valid(old_file)
+
+  if test_uvf_old then begin
+    if n_elements(index) gt 0 then begin
+      file_struct.(tag_loc)[index] = old_file
+    endif else begin
+      file_struct.(tag_loc) = old_file
+    endelse
+  endif
+
+return, test_uvf_old
+end

--- a/ps_wrappers/ps_filenames.pro
+++ b/ps_wrappers/ps_filenames.pro
@@ -29,14 +29,14 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
 
   if n_elements(dirty_folder) gt 0 then begin
     if n_elements(dirty_folder) ne n_elements(folder_names) then begin
-      message, 'If dirty_folder is provided it must contain the same number of ' +
+      message, 'If dirty_folder is provided it must contain the same number of ' + $
         'elements as folder_names'
     endif
   endif
 
   if n_elements(dirty_obsname) gt 0 then begin
     if n_elements(obs_names_in) ne n_elements(dirty_obsname) then begin
-      message, 'If dirty_obsname is provided it must contain the same number ' +
+      message, 'If dirty_obsname is provided it must contain the same number ' + $
         'of elements as obs_names_in'
     endif
     if n_elements(dirty_folder) eq 0 then dirty_folder = folder_names
@@ -67,7 +67,7 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
       folder_names = replicate(folder_names, n_filesets)
     endif
     if n_elements(folder_names) ne n_filesets then begin
-      message, 'If both folder_names and obs_names_in are arrays, the number ' +
+      message, 'If both folder_names and obs_names_in are arrays, the number ' + $
         'of elements must match'
     endif
 
@@ -75,7 +75,7 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
       ps_foldernames = replicate(ps_foldernames, n_filesets)
     endif
     if n_elements(ps_foldernames) ne n_filesets then begin
-      message, 'If both ps_foldernames and obs_names_in are arrays, the number ' +
+      message, 'If both ps_foldernames and obs_names_in are arrays, the number ' + $
         'of elements must match'
     endif
 
@@ -97,7 +97,7 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
       data_subdirs = replicate(data_subdirs, n_filesets)
     endif
     if n_elements(data_subdirs) ne n_filesets then begin
-      message, 'If data_subdirs is an array, the number of elements must match ' +
+      message, 'If data_subdirs is an array, the number of elements must match ' + $
         'the max of folder_names & obs_names_in'
     endif
 
@@ -106,7 +106,7 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
         save_paths = replicate(save_paths, n_filesets)
       endif
       if n_elements(save_paths) ne n_filesets then begin
-        message, 'If save_paths is an array, the number of elements must match '+
+        message, 'If save_paths is an array, the number of elements must match ' + $
           'the max of folder_names & obs_names_in'
       endif
     endif else begin
@@ -118,7 +118,7 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
         plot_paths = replicate(plot_paths, n_filesets)
       endif
       if n_elements(plot_paths) ne n_filesets then begin
-        message, 'If plot_paths is an array, the number of elements must match ' +
+        message, 'If plot_paths is an array, the number of elements must match ' + $
           'the max of folder_names & obs_names_in'
       endif
     endif else begin
@@ -279,10 +279,11 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
         if n_elements(dirty_folder) gt 0 then begin
           dirtyfile_list = file_search(dirty_folder[i] + '/' + data_subdirs[i] + $
             dirty_obsname[i] + '*_image*MHz*.fits', count = n_dirtyfiles)
+
           if n_dirtyfiles eq 0 then begin
             dirtyfile_list = file_search(dirty_folder[i] + '/' + data_subdirs[i] + $
               dirty_obsname[i] + '*_image*.fits', count = n_dirtyfiles)
-
+          endif
           if n_dirtyfiles gt 0 then begin
             if dirty_obsname[i] eq '' then begin
               dirty_obsname_arr = strmid(file_basename(dirtyfile_list), 0, $
@@ -307,8 +308,10 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
         ;; now get weights & variance files
         weightfile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
           obs_names[i] + '*_weights*MHz*.fits', count = n_wtfiles)
-        if n_wtfiles eq 0 then weightfile_list = file_search(folder_names[i] + $
-          '/' + data_subdirs[i] + obs_names[i] + '*_weights*.fits', count = n_wtfiles)
+        if n_wtfiles eq 0 then begin
+          weightfile_list = file_search(folder_names[i] + $
+            '/' + data_subdirs[i] + obs_names[i] + '*_weights*.fits', count = n_wtfiles)
+        endif
         if not keyword_set(no_wtvar_rts) then begin
           if n_wtfiles ne n_elements(fits_files) and info_files[i] eq '' then begin
             message, 'number of weight files does not match number of datafiles'
@@ -317,8 +320,10 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
 
         variancefile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
           obs_names[i] + '*_variance*MHz*.fits', count = n_varfiles)
-        if n_varfiles eq 0 then variancefile_list = file_search(folder_names[i] + $
-          '/' + data_subdirs[i] + obs_names[i] + '*_variance*.fits', count = n_varfiles)
+        if n_varfiles eq 0 then begin
+          variancefile_list = file_search(folder_names[i] + $
+            '/' + data_subdirs[i] + obs_names[i] + '*_variance*.fits', count = n_varfiles)
+        endif
         if not keyword_set(no_wtvar_rts) then begin
           if n_varfiles ne n_elements(fits_files) and info_files[i] eq '' then begin
             message, 'number of variance files does not match number of datafiles'
@@ -347,7 +352,7 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
         tag = 'fs' + number_formatter(i)
         if n_cubefiles gt 0 then begin
           cubefiles = create_struct(cubefiles, tag, cube_files)
-        endif elsebegin
+        endif else begin
           cubefiles = create_struct(cubefiles, tag, '')
         endelse
         if n_fitsfiles gt 0 then begin
@@ -1029,7 +1034,7 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
             integrated[i]=1
             print, 'Only found uvf_input cubes, switching to uvf_input.'
             uvf_input=1
-            
+
             ;; look for beam files
             beam_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
               'Combined_obs_' + obs_names[i] + '*gridded*beam2*image*.sav', count = n_beamfiles)
@@ -1153,7 +1158,7 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
             endif
             print, 'Only found uvf_input cubes, switching to uvf_input.'
             uvf_input=1
-            
+
             ;; look for beam files
             beam_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
               obs_names[i] + '*gridded*beam2*image*.sav', count = n_beamfiles)
@@ -1200,8 +1205,9 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
       if ps_foldernames[0] ne ps_foldernames[1] then begin
         nominal_savepaths = folder_names + path_sep() + ps_foldernames
       endif
-    endif
-    else nominal_savepaths = folder_names
+    endif else begin
+      nominal_savepaths = folder_names
+    endelse
     if n_elements(nominal_savepaths) eq 2 then begin
       folderparts_1 = strsplit(nominal_savepaths[0], path_sep(), /extract)
       folderparts_2 = strsplit(nominal_savepaths[1], path_sep(), /extract)

--- a/ps_wrappers/ps_filenames.pro
+++ b/ps_wrappers/ps_filenames.pro
@@ -1,91 +1,163 @@
-function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, dirty_obsname = dirty_obsname, sim=sim,$
-    rts = rts, uvf_input = uvf_input, casa = casa, $
-    data_subdirs = data_subdirs, ps_foldernames = ps_foldernames, plot_paths = plot_paths, save_paths = save_paths, $
-    refresh_info = refresh_info, exact_obsnames = exact_obsnames, no_wtvar_rts = no_wtvar_rts
-    
-  if n_elements(folder_names) eq 2 then if folder_names[0] eq folder_names[1] then folder_names = folder_names[0]
-  
-  if n_elements(obs_names_in) eq 2 then if obs_names_in[0] eq obs_names_in[1] then obs_names_in = obs_names_in[0]
-  
+function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, $
+    dirty_obsname = dirty_obsname, sim = sim, rts = rts, casa = casa, $
+    uvf_input = uvf_input, data_subdirs = data_subdirs, $
+    ps_foldernames = ps_foldernames, plot_paths = plot_paths, $
+    save_paths = save_paths, refresh_info = refresh_info, $
+    exact_obsnames = exact_obsnames, no_wtvar_rts = no_wtvar_rts
+
+  if n_elements(folder_names) eq 2 then begin
+    if folder_names[0] eq folder_names[1] then folder_names = folder_names[0]
+  endif
+
+  if n_elements(obs_names_in) eq 2 then begin
+    if obs_names_in[0] eq obs_names_in[1] then obs_names_in = obs_names_in[0]
+  endif
+
   n_filesets = max([n_elements(folder_names), n_elements(obs_names_in), n_elements(ps_foldernames)])
-  
-  if n_elements(data_subdirs) eq 0 and not keyword_set(uvf_input) then data_subdirs = 'Healpix' + path_sep() else begin
+
+  if n_elements(data_subdirs) eq 0 and not keyword_set(uvf_input) then begin
+    data_subdirs = 'Healpix' + path_sep()
+  endif else begin
     ;; make sure there is no path separator at beginning and there is one at the end
-    for i=0, n_elements(data_subdirs)-1 do if data_subdirs[i] ne '' then data_subdirs[i] = strjoin(strsplit(data_subdirs[i], path_sep(), /extract), path_sep()) + path_sep()
+    for i=0, n_elements(data_subdirs)-1 do begin
+      if data_subdirs[i] ne '' then begin
+        data_subdirs[i] = strjoin(strsplit(data_subdirs[i], path_sep(), /extract), $
+          path_sep()) + path_sep()
+      endif
+    endfor
   endelse
-  
-  if n_elements(dirty_folder) gt 0 then if n_elements(dirty_folder) ne n_elements(folder_names) then $
-    message, 'If dirty_folder is provided it must contain the same number of elements as folder_names'
-    
+
+  if n_elements(dirty_folder) gt 0 then begin
+    if n_elements(dirty_folder) ne n_elements(folder_names) then begin
+      message, 'If dirty_folder is provided it must contain the same number of ' +
+        'elements as folder_names'
+    endif
+  endif
+
   if n_elements(dirty_obsname) gt 0 then begin
-    if n_elements(obs_names_in) ne n_elements(dirty_obsname) then $
-      message, 'If dirty_obsname is provided it must contain the same number of elements as obs_names_in'
-      
+    if n_elements(obs_names_in) ne n_elements(dirty_obsname) then begin
+      message, 'If dirty_obsname is provided it must contain the same number ' +
+        'of elements as obs_names_in'
+    endif
     if n_elements(dirty_folder) eq 0 then dirty_folder = folder_names
   endif
-  
-  if n_elements(dirty_folder) gt 0 and n_elements(dirty_obsname) eq 0 then dirty_obsname = ''
-  
-  if not keyword_set(rts) and n_elements(data_subdirs) eq 0 then begin
-    if keyword_set(uvf_input) then data_subdirs = '' else data_subdirs = 'Healpix' + path_sep()
+
+  if n_elements(dirty_folder) gt 0 and n_elements(dirty_obsname) eq 0 then begin
+    dirty_obsname = ''
   endif
-  
+
+  if not keyword_set(rts) and n_elements(data_subdirs) eq 0 then begin
+    if keyword_set(uvf_input) then begin
+      data_subdirs = ''
+    endif else begin
+      data_subdirs = 'Healpix' + path_sep()
+    endelse
+  endif
+
   if n_elements(ps_foldernames) eq 0 then ps_foldernames = 'ps'
-  if n_elements(save_paths) eq 0 then save_paths = folder_names + path_sep() + ps_foldernames + path_sep()
-  if n_elements(plot_paths) eq 0 then plot_paths = save_paths + 'plots' + path_sep()
+  if n_elements(save_paths) eq 0 then begin
+    save_paths = folder_names + path_sep() + ps_foldernames + path_sep()
+  endif
+  if n_elements(plot_paths) eq 0 then begin
+    plot_paths = save_paths + 'plots' + path_sep()
+  endif
 
   if n_filesets gt 1 then begin
-    if n_elements(folder_names) eq 1 then folder_names = replicate(folder_names, n_filesets)
-    if n_elements(folder_names) ne n_filesets then message, 'If both folder_names and obs_names_in are arrays, the number of elements must match'
-    
-    if n_elements(ps_foldernames) eq 1 then ps_foldernames = replicate(ps_foldernames, n_filesets)
-    if n_elements(ps_foldernames) ne n_filesets then message, 'If both ps_foldernames and obs_names_in are arrays, the number of elements must match'
-    
-    if n_elements(dirty_folder) eq 1 then dirty_folder = replicate(folder_names, n_filesets)
-    if n_elements(dirty_obsname) eq 1 then dirty_obsname = replicate(dirty_obsname, n_filesets)
-    
-    if n_elements(obs_names_in) eq 1 then obs_names_in = replicate(obs_names_in, n_filesets)
-    if n_elements(obs_names_in) gt 0 and n_elements(obs_names_in) ne n_filesets then message, 'If both folder_names and obs_names_in are arrays, the number of elements must match'
-    
-    if n_elements(data_subdirs) eq 1 then data_subdirs = replicate(data_subdirs, n_filesets)
-    if n_elements(data_subdirs) ne n_filesets then message, 'If data_subdirs is an array, the number of elements must match the max of folder_names & obs_names_in'
-    
+    if n_elements(folder_names) eq 1 then begin
+      folder_names = replicate(folder_names, n_filesets)
+    endif
+    if n_elements(folder_names) ne n_filesets then begin
+      message, 'If both folder_names and obs_names_in are arrays, the number ' +
+        'of elements must match'
+    endif
+
+    if n_elements(ps_foldernames) eq 1 then begin
+      ps_foldernames = replicate(ps_foldernames, n_filesets)
+    endif
+    if n_elements(ps_foldernames) ne n_filesets then begin
+      message, 'If both ps_foldernames and obs_names_in are arrays, the number ' +
+        'of elements must match'
+    endif
+
+    if n_elements(dirty_folder) eq 1 then begin
+      dirty_folder = replicate(folder_names, n_filesets)
+    endif
+    if n_elements(dirty_obsname) eq 1 then begin
+      dirty_obsname = replicate(dirty_obsname, n_filesets)
+    endif
+
+    if n_elements(obs_names_in) eq 1 then begin
+      obs_names_in = replicate(obs_names_in, n_filesets)
+    endif
+    if n_elements(obs_names_in) gt 0 and n_elements(obs_names_in) ne n_filesets then begin
+      message, 'If both folder_names and obs_names_in are arrays, the number of elements must match'
+    endif
+
+    if n_elements(data_subdirs) eq 1 then begin
+      data_subdirs = replicate(data_subdirs, n_filesets)
+    endif
+    if n_elements(data_subdirs) ne n_filesets then begin
+      message, 'If data_subdirs is an array, the number of elements must match ' +
+        'the max of folder_names & obs_names_in'
+    endif
+
     if n_elements(save_paths) gt 0 then begin
-      if n_elements(save_paths) eq 1 then save_paths = replicate(save_paths, n_filesets)
-      if n_elements(save_paths) ne n_filesets then message, 'If save_paths is an array, the number of elements must match the max of folder_names & obs_names_in'
-    endif else save_paths = folder_names + '/' + data_subdirs
-    
+      if n_elements(save_paths) eq 1 then begin
+        save_paths = replicate(save_paths, n_filesets)
+      endif
+      if n_elements(save_paths) ne n_filesets then begin
+        message, 'If save_paths is an array, the number of elements must match '+
+          'the max of folder_names & obs_names_in'
+      endif
+    endif else begin
+      save_paths = folder_names + '/' + data_subdirs
+    endelse
+
     if n_elements(plot_paths) gt 0 then begin
-      if n_elements(plot_paths) eq 1 then plot_paths = replicate(plot_paths, n_filesets)
-      if n_elements(plot_paths) ne n_filesets then message, 'If plot_paths is an array, the number of elements must match the max of folder_names & obs_names_in'
-    endif else plot_paths = folder_names + '/' + data_subdirs
+      if n_elements(plot_paths) eq 1 then begin
+        plot_paths = replicate(plot_paths, n_filesets)
+      endif
+      if n_elements(plot_paths) ne n_filesets then begin
+        message, 'If plot_paths is an array, the number of elements must match ' +
+          'the max of folder_names & obs_names_in'
+      endif
+    endif else begin
+      plot_paths = folder_names + '/' + data_subdirs
+    endelse
   endif else begin
-  
-    if n_elements(save_paths) eq 0 then save_paths = folder_names + '/' + data_subdirs
-    if n_elements(plot_paths) eq 0 then plot_paths = folder_names + '/' + data_subdirs
+    if n_elements(save_paths) eq 0 then begin
+      save_paths = folder_names + '/' + data_subdirs
+    endif
+    if n_elements(plot_paths) eq 0 then begin
+      plot_paths = folder_names + '/' + data_subdirs
+    endif
   endelse
-  
+
   ;; make sure save & plot paths end in path_sep()
   pos = strpos(save_paths, path_sep(), /reverse_search)
   wh_nosep = where(pos+1-strlen(save_paths) lt 0, count_nosep)
-  if count_nosep gt 0 then save_paths[wh_nosep] = save_paths[wh_nosep] + path_sep()
-  
+  if count_nosep gt 0 then begin
+    save_paths[wh_nosep] = save_paths[wh_nosep] + path_sep()
+  endif
+
   pos = strpos(plot_paths, path_sep(), /reverse_search)
   wh_nosep = where(pos+1-strlen(plot_paths) lt 0, count_nosep)
-  if count_nosep gt 0 then plot_paths[wh_nosep] = plot_paths[wh_nosep] + path_sep()
-  
+  if count_nosep gt 0 then begin
+    plot_paths[wh_nosep] = plot_paths[wh_nosep] + path_sep()
+  endif
+
   if keyword_set(rts) then begin
     obs_names = strarr(n_filesets)
     rts_types = strarr(n_filesets)
     folder_basenames = strarr(n_filesets)
     info_files = strarr(n_filesets)
     ;integrated = intarr(n_filesets)
-    
+
     for i=0, n_filesets-1 do begin
-    
+
       folder_basenames[i] = file_basename(folder_names[i])
       rts_types[i] = folder_basenames[i]
-      
+
       if n_elements(obs_names_in) gt 0 then begin
         if size(obs_names_in,/type) eq 7 then begin
           obs_names[i] = obs_names_in[i]
@@ -98,57 +170,72 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
         obs_names[i] = ''
         obs_name_single = ''
       endelse
-      
+
       ;; first look for info files in save_path
       if not keyword_set(refresh_info) then begin
-        info_file = file_search(save_paths[i] + obs_names[i] + '*info*', count = n_infofile)
+        info_file = file_search(save_paths[i] + obs_names[i] + '*info*', $
+          count = n_infofile)
         if n_infofile gt 0 then begin
           if obs_names[i] eq '' then begin
             info_files[i] = info_file[0]
-            ;obs_names[i] = stregex(file_basename(info_files[i]), '[0-9]+.[0-9]+_', /extract)
-            obs_names[i] = strmid(file_basename(info_files[i]), 0, reform(strpos(file_basename(info_files[i]), '_image')))
+            obs_names[i] = strmid(file_basename(info_files[i]), 0, $
+              reform(strpos(file_basename(info_files[i]), '_image')))
             if n_infofile gt 1 then begin
               print, 'More than 1 info files found, using first one'
               rts_types[i] = rts_types[i] + '_' + obs_names[i]
             endif
           endif else begin
-            if n_infofile gt 1 then message, 'More than one info file found with given obs_name'
+            if n_infofile gt 1 then begin
+              message, 'More than one info file found with given obs_name'
+            endif
             info_files[i] = info_file[0]
             test_other_obsnames = file_search(save_paths[i] + '*info*', count = n_all_infofile)
-            if n_all_infofile gt n_infofile then rts_types[i] = rts_types[i] + '_' + obs_names[i]
+            if n_all_infofile gt n_infofile then begin
+              rts_types[i] = rts_types[i] + '_' + obs_names[i]
+            endif
           endelse
-          
+
         endif
       endif
-      
+
       ;; then look for combined cube files in folder + data_subdir
-      cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_cube.idlsave', count = n_cubefiles)
+      cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+        obs_names[i] + '*_cube.idlsave', count = n_cubefiles)
       if n_cubefiles gt 0 then begin
         if obs_names[i] eq '' then begin
-          ;obs_name_arr = stregex(file_basename(cube_file_list), '[0-9]+.[0-9]+_', /extract)
-          obs_name_arr = strmid(file_basename(cube_file_list), 0, reform(strpos(file_basename(cube_file_list), '_image'), 1, n_cubefiles))
+          obs_name_arr = strmid(file_basename(cube_file_list), 0, $
+            reform(strpos(file_basename(cube_file_list), '_image'), 1, n_cubefiles))
           wh_first = where(obs_name_arr eq obs_name_arr[0], count_first)
           cube_files = cube_file_list[wh_first]
           obs_names[i] = obs_name_arr[0]
           if count_first lt n_cubefiles then begin
-            print, 'More than one obs_name found, using first obs_name (' + obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
-            if n_elements(info_files) eq 0 then rts_types[i] = rts_types[i] + '_' + obs_names[i]
+            print, 'More than one obs_name found, using first obs_name (' + $
+              obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
+            if n_elements(info_files) eq 0 then begin
+              rts_types[i] = rts_types[i] + '_' + obs_names[i]
+            endif
           endif
         endif else begin
           cube_files = cube_file_list
-          
+
           if n_elements(info_files) eq 0 then begin
-            test_other_obsnames = file_search(folder_names[i] + '/' + data_subdirs[i] + '*_cube.idlsave', count = n_all_cubefiles)
-            if n_all_cubefiles gt n_cubefiles then rts_types[i] = rts_types[i] + '_' + obs_names[i]
+            test_other_obsnames = file_search(folder_names[i] + '/' + $
+              data_subdirs[i] + '*_cube.idlsave', count = n_all_cubefiles)
+            if n_all_cubefiles gt n_cubefiles then begin
+              rts_types[i] = rts_types[i] + '_' + obs_names[i]
+            endif
           endif
         endelse
-        
+
       endif
-      
+
       ;; then look for original fits files
-      fits_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_image*MHz*.fits', count = n_fitsfiles)
-      if n_fitsfiles eq 0 then fits_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_image*.fits', count = n_fitsfiles)
-      wh_cube = where(stregex(fits_file_list, 'cube', /boolean), count_cube, complement = wh_orig, ncomplement = count_orig)
+      fits_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+        obs_names[i] + '*_image*MHz*.fits', count = n_fitsfiles)
+      if n_fitsfiles eq 0 then fits_file_list = file_search(folder_names[i] + $
+        '/' + data_subdirs[i] + obs_names[i] + '*_image*.fits', count = n_fitsfiles)
+      wh_cube = where(stregex(fits_file_list, 'cube', /boolean), count_cube, $
+        complement = wh_orig, ncomplement = count_orig)
       if count_cube gt 0 then begin
         if count_orig gt 0 then begin
           fits_file_list = fits_file_list[wh_orig]
@@ -160,97 +247,146 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
       endif
       if n_fitsfiles gt 0 then begin
         if obs_names[i] eq '' then begin
-          ;obs_name_arr = stregex(file_basename(fits_file_list), '[0-9]+.[0-9]+_', /extract)
-          obs_name_arr = strmid(file_basename(fits_file_list), 0, reform(strpos(file_basename(fits_file_list), '_image'), 1, n_fitsfiles))
+          obs_name_arr = strmid(file_basename(fits_file_list), 0, $
+            reform(strpos(file_basename(fits_file_list), '_image'), 1, n_fitsfiles))
           wh_first = where(obs_name_arr eq obs_name_arr[0], count_first)
-          if count_first lt n_fitsfiles then $
-            print, 'More than one obs_name found, using first obs_name (' + obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
-            
+          if count_first lt n_fitsfiles then begin
+            print, 'More than one obs_name found, using first obs_name (' + $
+              obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
+          endif
+
           fits_files = fits_file_list[wh_first]
           obs_names[i] = obs_name_arr[0]
         endif else begin
           fits_files = fits_file_list
         endelse
       endif
-      
-      if n_elements(cube_files) eq 0 and n_elements(fits_files) eq 0 and info_files[i] eq '' then message, 'No cube or info files found in folder ' + folder_names[i]
-      
+
+      if n_elements(cube_files) eq 0 and n_elements(fits_files) eq 0 $
+          and info_files[i] eq '' then begin
+        message, 'No cube or info files found in folder ' + folder_names[i]
+      endif
+
       if n_elements(fits_files) eq 0 then begin
         fits_file_list = ''
         weightfile_list = ''
         variancefile_list = ''
-        if n_elements(dirty_folder) gt 0 then dirtyfile_list = ''
-      endif else begin
-      
         if n_elements(dirty_folder) gt 0 then begin
-          dirtyfile_list = file_search(dirty_folder[i] + '/' + data_subdirs[i] + dirty_obsname[i] + '*_image*MHz*.fits', count = n_dirtyfiles)
-          if n_dirtyfiles eq 0 then dirtyfile_list = file_search(dirty_folder[i] + '/' + data_subdirs[i] + dirty_obsname[i] + '*_image*.fits', count = n_dirtyfiles)
-          
+          dirtyfile_list = ''
+        endif
+      endif else begin
+
+        if n_elements(dirty_folder) gt 0 then begin
+          dirtyfile_list = file_search(dirty_folder[i] + '/' + data_subdirs[i] + $
+            dirty_obsname[i] + '*_image*MHz*.fits', count = n_dirtyfiles)
+          if n_dirtyfiles eq 0 then begin
+            dirtyfile_list = file_search(dirty_folder[i] + '/' + data_subdirs[i] + $
+              dirty_obsname[i] + '*_image*.fits', count = n_dirtyfiles)
+
           if n_dirtyfiles gt 0 then begin
             if dirty_obsname[i] eq '' then begin
-              dirty_obsname_arr = strmid(file_basename(dirtyfile_list), 0, reform(strpos(file_basename(dirtyfile_list), '_image'), 1, n_dirtyfiles))
+              dirty_obsname_arr = strmid(file_basename(dirtyfile_list), 0, $
+                reform(strpos(file_basename(dirtyfile_list), '_image'), 1, n_dirtyfiles))
               wh_first = where(dirty_obsname_arr eq dirty_obsname_arr[0], count_first)
-              if count_first lt n_dirtyfiles then $
-                print, 'More than one dirty_obsname found, using first obs_name (' + dirty_obsname_arr[0] + ', ' + number_formatter(count_first) + ' files)'
-                
+              if count_first lt n_dirtyfiles then begin
+                print, 'More than one dirty_obsname found, using first obs_name (' + $
+                  dirty_obsname_arr[0] + ', ' + number_formatter(count_first) + ' files)'
+              endif
               dirty_files = dirtyfile_list[wh_first]
               dirty_obsname[i] = dirty_obsname_arr[0]
             endif else begin
               dirty_files = dirtyfile_list
             endelse
           endif
-          if n_elements(dirty_files) ne n_elements(fits_files) and info_files[i] eq '' $
-            then message, 'number of dirty files does not match number of datafiles'
-            
+          if n_elements(dirty_files) ne n_elements(fits_files) and $
+              info_files[i] eq '' then begin
+            message, 'number of dirty files does not match number of datafiles'
+          endif
         endif
-        
+
         ;; now get weights & variance files
-        weightfile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_weights*MHz*.fits', count = n_wtfiles)
-        if n_wtfiles eq 0 then weightfile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_weights*.fits', count = n_wtfiles)
-        if not keyword_set(no_wtvar_rts) then if n_wtfiles ne n_elements(fits_files) and info_files[i] eq '' $
-          then message, 'number of weight files does not match number of datafiles'
-          
-        variancefile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_variance*MHz*.fits', count = n_varfiles)
-        if n_varfiles eq 0 then variancefile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_variance*.fits', count = n_varfiles)
-        if not keyword_set(no_wtvar_rts) then if n_varfiles ne n_elements(fits_files) and info_files[i] eq '' $
-          then message, 'number of variance files does not match number of datafiles'
+        weightfile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+          obs_names[i] + '*_weights*MHz*.fits', count = n_wtfiles)
+        if n_wtfiles eq 0 then weightfile_list = file_search(folder_names[i] + $
+          '/' + data_subdirs[i] + obs_names[i] + '*_weights*.fits', count = n_wtfiles)
+        if not keyword_set(no_wtvar_rts) then begin
+          if n_wtfiles ne n_elements(fits_files) and info_files[i] eq '' then begin
+            message, 'number of weight files does not match number of datafiles'
+          endif
+        endif
+
+        variancefile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+          obs_names[i] + '*_variance*MHz*.fits', count = n_varfiles)
+        if n_varfiles eq 0 then variancefile_list = file_search(folder_names[i] + $
+          '/' + data_subdirs[i] + obs_names[i] + '*_variance*.fits', count = n_varfiles)
+        if not keyword_set(no_wtvar_rts) then begin
+          if n_varfiles ne n_elements(fits_files) and info_files[i] eq '' then begin
+            message, 'number of variance files does not match number of datafiles'
+          endif
+        endif
       endelse
-      
+
       if i eq 0 then begin
         tag = 'fs' + number_formatter(i)
-        if n_cubefiles gt 0 then cubefiles = create_struct(tag, cube_files) else cubefiles = create_struct(tag, '')
-        if n_fitsfiles gt 0 then datafiles = create_struct(tag, fits_files) else datafiles = create_struct(tag, '')
+        if n_cubefiles gt 0 then begin
+          cubefiles = create_struct(tag, cube_files)
+        endif else begin
+          cubefiles = create_struct(tag, '')
+        endelse
+        if n_fitsfiles gt 0 then begin
+          datafiles = create_struct(tag, fits_files)
+        endif else begin
+          datafiles = create_struct(tag, '')
+        endelse
         weightfiles = create_struct(tag, weightfile_list)
         variancefiles = create_struct(tag, variancefile_list)
-        if n_elements(dirty_folder) gt 0 then dirtyfiles = create_struct(tag, dirty_files)
+        if n_elements(dirty_folder) gt 0 then begin
+          dirtyfiles = create_struct(tag, dirty_files)
+        endif
       endif else begin
         tag = 'fs' + number_formatter(i)
-        if n_cubefiles gt 0 then cubefiles = create_struct(cubefiles, tag, cube_files) else cubefiles = create_struct(cubefiles, tag, '')
-        if n_fitsfiles gt 0 then datafiles = create_struct(datafiles, tag, fits_files) else datafiles = create_struct(datafiles, tag, '')
+        if n_cubefiles gt 0 then begin
+          cubefiles = create_struct(cubefiles, tag, cube_files)
+        endif elsebegin
+          cubefiles = create_struct(cubefiles, tag, '')
+        endelse
+        if n_fitsfiles gt 0 then begin
+          datafiles = create_struct(datafiles, tag, fits_files)
+        endif else begin
+          datafiles = create_struct(datafiles, tag, '')
+        endelse
         weightfiles = create_struct(weightfiles, tag, weightfile_list)
         variancefiles = create_struct(variancefiles, tag, variancefile_list)
-        if n_elements(dirty_folder) gt 0 then dirtyfiles = create_struct(dirtyfiles, tag, dirty_files)
+        if n_elements(dirty_folder) gt 0 then begin
+          dirtyfiles = create_struct(dirtyfiles, tag, dirty_files)
+        endif
       endelse
-      undefine, fits_files, weightfile_list, variancefile_list, cube_files, dirty_files, dirtyfile_list
-      
+      undefine, fits_files, weightfile_list, variancefile_list, cube_files, $
+        dirty_files, dirtyfile_list
+
     endfor
-    
-    obs_info = {folder_names:folder_names, folder_basenames:folder_basenames, obs_names:obs_names, info_files:info_files, cube_files:cubefiles, $
-      datafiles:datafiles, weightfiles:weightfiles, variancefiles:variancefiles, rts_types:rts_types, plot_paths:plot_paths, save_paths:save_paths}
-      
-    if n_elements(dirty_folder) then obs_info = create_struct(obs_info, 'dirtyfiles', dirtyfiles)
-    
+
+    obs_info = {folder_names:folder_names, folder_basenames:folder_basenames, $
+      obs_names:obs_names, info_files:info_files, cube_files:cubefiles, $
+      datafiles:datafiles, weightfiles:weightfiles, variancefiles:variancefiles, $
+      rts_types:rts_types, plot_paths:plot_paths, save_paths:save_paths}
+
+    if n_elements(dirty_folder) then begin
+      obs_info = create_struct(obs_info, 'dirtyfiles', dirtyfiles)
+    endif
+
   endif else if keyword_set(casa) then begin
     obs_names = strarr(n_filesets)
     casa_types = strarr(n_filesets)
     info_files = strarr(n_filesets)
     ;integrated = intarr(n_filesets)
-    
+
     for i=0, n_filesets-1 do begin
-      ;; check for folder existence, otherwise look for common folder names to figure out full path. If none found, try base_path('data') + 'mit_data/'
-    
+      ;; check for folder existence, otherwise look for common folder names to
+      ;; figure out full path. If none found, try base_path('data') + 'mit_data/'
+
       casa_types[i] = file_basename(folder_names[i])
-      
+
       if n_elements(obs_names_in) gt 0 then begin
         if size(obs_names_in,/type) eq 7 then begin
           obs_names[i] = obs_names_in[i]
@@ -263,7 +399,7 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
         obs_names[i] = ''
         obs_name_single = ''
       endelse
-      
+
       ;; first look for info files in save_paths
       info_file = file_search(save_paths[i] + obs_names[i] + '*info*', count = n_infofile)
       if n_infofile gt 0 then begin
@@ -275,40 +411,40 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
           if n_infofile gt 1 then message, 'More than one info file found with given obs_name'
           info_files[i] = info_file[0]
         endelse
-        
+
       endif
-      
+
       ;; then look for cube files in folder + data_subdir
-      cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_holo_[xy]*.fits', count = n_cubefiles)
+      cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+        obs_names[i] + '*_holo_[xy]*.fits', count = n_cubefiles)
       if n_cubefiles gt 0 then begin
-        ;        if obs_names[i] eq '' then begin
-        ;          obs_name_arr = stregex(cube_file_list, '[0-9]+.[0-9]+_', /extract)
-        ;          wh_first = where(obs_name_arr eq obs_name_arr[0], count_first)
-        ;          if count_first lt n_cubefiles then $
-        ;            print, 'More than one obs_name found, using first obs_name (' + obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
-        ;          datafiles = cube_file_list[wh_first]
-        ;          obs_names[i] = obs_name_arr[0]
-        ;        endif else begin
         datafiles = cube_file_list
-      ;        endelse
-        
+
       endif
-      
+
       ;; now get weights & variance files
-      weightfile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_psf_*.fits', count = n_wtfiles)
-      if n_wtfiles ne n_elements(datafiles) and info_files[i] eq '' then message, 'number of weight files does not match number of datafiles'
-      
-      variancefile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*psfbeamsquare*.fits', count = n_varfiles)
-      if n_varfiles ne n_elements(datafiles) and info_files[i] eq '' then message, 'number of variance files does not match number of datafiles'
-      
-      if n_elements(datafiles) eq 0 and info_files[i] eq '' then message, 'No cube or info files found in folder ' + folder_names[i]
-      
+      weightfile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+        obs_names[i] + '*_psf_*.fits', count = n_wtfiles)
+      if n_wtfiles ne n_elements(datafiles) and info_files[i] eq '' then begin
+        message, 'number of weight files does not match number of datafiles'
+      endif
+
+      variancefile_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+        obs_names[i] + '*psfbeamsquare*.fits', count = n_varfiles)
+      if n_varfiles ne n_elements(datafiles) and info_files[i] eq '' then begin
+        message, 'number of variance files does not match number of datafiles'
+      endif
+
+      if n_elements(datafiles) eq 0 and info_files[i] eq '' then begin
+        message, 'No cube or info files found in folder ' + folder_names[i]
+      endif
+
       if n_elements(datafiles) eq 0 then begin
         datafiles = ''
         weightfile_list = ''
         variancefile_list = ''
       endif
-      
+
       if i eq 0 then begin
         tag = 'fs' + number_formatter(i)
         cube_files = create_struct(tag, datafiles)
@@ -321,12 +457,14 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
         variancefiles = create_struct(variancefiles, tag, variancefile_list)
       endelse
       undefine, datafiles, weightfile_list, variancefile_list
-      
+
     endfor
-    
-    obs_info = {folder_names:folder_names, obs_names:obs_names, info_files:info_files, cube_files:cube_files, $
-      weightfiles:weightfiles, variancefiles:variancefiles, casa_types:casa_types, plot_paths:plot_paths, save_paths:save_paths}
-      
+
+    obs_info = {folder_names:folder_names, obs_names:obs_names, $
+      info_files:info_files, cube_files:cube_files, weightfiles:weightfiles, $
+      variancefiles:variancefiles, casa_types:casa_types, plot_paths:plot_paths, $
+      save_paths:save_paths}
+
   endif else begin
     ; FHD
     obs_names = strarr(n_filesets)
@@ -334,12 +472,12 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
     folder_basenames = strarr(n_filesets)
     info_files = strarr(n_filesets)
     integrated = intarr(n_filesets)
-    
+
     for i=0, n_filesets-1 do begin
-    
+
       folder_basenames[i] = file_basename(folder_names[i])
       fhd_types[i] = folder_basenames[i]
-      
+
       if n_elements(obs_names_in) gt 0 then begin
         if size(obs_names_in,/type) eq 7 then begin
           obs_names[i] = obs_names_in[i]
@@ -352,10 +490,10 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
         obs_names[i] = ''
         obs_name_single = ''
       endelse
-      
+
       hpx_endobsname_tag = '_cube'
       uvf_endobsname_tag = '_gridded'
-      
+
       if keyword_set(uvf_input) then begin
         uvf_info_tag = '_uvf'
         endobsname_tag_use = hpx_endobsname_tag
@@ -365,11 +503,15 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
       endelse
       ;; first look for integrated info files in save_paths with names like Combined_obs_...
       if keyword_set(exact_obsnames) then begin
-        hpx_info_file = file_search(save_paths[i] +  'Combined_obs_' + obs_names[i] + hpx_endobsname_tag + '*info*', count = n_hpx)
-        uvf_info_file = file_search(save_paths[i] +  'Combined_obs_' + obs_names[i] + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
+        hpx_info_file = file_search(save_paths[i] +  'Combined_obs_' + $
+          obs_names[i] + hpx_endobsname_tag + '*info*', count = n_hpx)
+        uvf_info_file = file_search(save_paths[i] +  'Combined_obs_' + $
+          obs_names[i] + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
       endif else begin
-        hpx_info_file = file_search(save_paths[i] +  'Combined_obs_' + obs_names[i] + '*' + hpx_endobsname_tag + '*info*', count = n_hpx)
-        uvf_info_file = file_search(save_paths[i] +  'Combined_obs_' + obs_names[i] + '*' + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
+        hpx_info_file = file_search(save_paths[i] +  'Combined_obs_' + $
+          obs_names[i] + '*' + hpx_endobsname_tag + '*info*', count = n_hpx)
+        uvf_info_file = file_search(save_paths[i] +  'Combined_obs_' + $
+          obs_names[i] + '*' + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
       endelse
       if keyword_set(uvf_input) then begin
         info_file = uvf_info_file
@@ -393,7 +535,8 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
             obs_names[i] = stregex(info_files[i], '[0-9]+-[0-9]+', /extract)
           endif else begin
             start_pos = strpos(info_files[i], 'Combined_obs_') + strlen('Combined_obs_')
-            end_pos = stregex(strmid(info_files[i], start_pos), hpx_endobsname_tag + '|' + uvf_endobsname_tag)
+            end_pos = stregex(strmid(info_files[i], start_pos), hpx_endobsname_tag + $
+              '|' + uvf_endobsname_tag)
             obs_names[i] = strmid(info_files[i], start_pos, end_pos)
           endelse
           if n_infofile gt 1 then begin
@@ -404,10 +547,13 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
           if n_infofile gt 1 then begin
             ;; try just using the exact obs_name
             if keyword_set(uvf_input) then begin
-              new_info_file = file_search(save_paths[i] +  'Combined_obs_' + obs_names[i] + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_infofile)
+              new_info_file = file_search(save_paths[i] +  'Combined_obs_' + $
+                obs_names[i] + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_infofile)
             endif else begin
-              hpx_info_file = file_search(save_paths[i] +  'Combined_obs_' + obs_names[i] + hpx_endobsname_tag + '*info*', count = n_hpx)
-              uvf_info_file = file_search(save_paths[i] +  'Combined_obs_' + obs_names[i] + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
+              hpx_info_file = file_search(save_paths[i] +  'Combined_obs_' + $
+                obs_names[i] + hpx_endobsname_tag + '*info*', count = n_hpx)
+              uvf_info_file = file_search(save_paths[i] +  'Combined_obs_' + $
+                obs_names[i] + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
               n_new_infofile = n_hpx + n_uvf
               if n_hpx gt 0 then begin
                 new_info_file = hpx_info_file
@@ -418,27 +564,39 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
               exact_obsnames=1
               info_file = new_info_file
               n_infofile = n_new_infofile
-            endif else message, 'More than one info file found with given obs_name'
+            endif else begin
+              message, 'More than one info file found with given obs_name'
+            endelse
           endif
           info_files[i] = info_file
-          if stregex(info_files[i], '[0-9]+-[0-9]+', /boolean) then obs_names[i] = stregex(info_files[i], '[0-9]+-[0-9]+', /extract) else begin
+          if stregex(info_files[i], '[0-9]+-[0-9]+', /boolean) then begin
+            obs_names[i] = stregex(info_files[i], '[0-9]+-[0-9]+', /extract)
+          endif else begin
             start_pos = strpos(info_files[i], 'Combined_obs_') + strlen('Combined_obs_')
-            end_pos = stregex(strmid(info_files[i], start_pos), hpx_endobsname_tag + '|' + uvf_endobsname_tag)
+            end_pos = stregex(strmid(info_files[i], start_pos), hpx_endobsname_tag + $
+              '|' + uvf_endobsname_tag)
             obs_names[i] = strmid(info_files[i], start_pos, end_pos)
           endelse
-          test_other_obsnames = file_search(save_paths[i] +  'Combined_obs_' + '*' + uvf_info_tag + '*info*', count = n_all_infofile)
-          if n_all_infofile gt n_infofile then fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
+          test_other_obsnames = file_search(save_paths[i] +  'Combined_obs_' + $
+            '*' + uvf_info_tag + '*info*', count = n_all_infofile)
+          if n_all_infofile gt n_infofile then begin
+            fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
+          endif
         endelse
         integrated[i]=1
-        
+
       endif else begin
         ;; then look for single obs info files
         if keyword_set(exact_obsnames) then begin
-          hpx_info_file = file_search(save_paths[i] + obs_name_single + hpx_endobsname_tag + '*info*', count = n_hpx)
-          uvf_info_file = file_search(save_paths[i] + obs_name_single + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
+          hpx_info_file = file_search(save_paths[i] + obs_name_single + $
+            hpx_endobsname_tag + '*info*', count = n_hpx)
+          uvf_info_file = file_search(save_paths[i] + obs_name_single + $
+            uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
         endif else begin
-          hpx_info_file = file_search(save_paths[i] + obs_name_single + '*' + hpx_endobsname_tag + '*info*', count = n_hpx)
-          uvf_info_file = file_search(save_paths[i] + obs_name_single + '*' + uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
+          hpx_info_file = file_search(save_paths[i] + obs_name_single + '*' + $
+            hpx_endobsname_tag + '*info*', count = n_hpx)
+          uvf_info_file = file_search(save_paths[i] + obs_name_single + '*' + $
+            uvf_endobsname_tag + uvf_info_tag + '*info*', count = n_uvf)
         endelse
         if keyword_set(uvf_input) then begin
           info_file = uvf_info_file
@@ -454,8 +612,8 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
               if n_uvf gt 0 then info_file = [info_file, uvf_info_file]
             endif else if n_uvf gt 0 then info_file = uvf_info_file
           endelse
-        endelse      
-        
+        endelse
+
         if n_infofile gt 0 then begin
           info_basename = file_basename(info_file)
           if obs_names[i] eq '' then begin
@@ -463,7 +621,8 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
             if stregex(info_basename[0], '[0-9]+', /boolean) then begin
               obs_names[i] = stregex(info_basename[0], '[0-9]+', /extract)
             endif else begin
-              end_pos = stregex(info_basename[0], hpx_endobsname_tag + '|' + uvf_endobsname_tag)
+              end_pos = stregex(info_basename[0], hpx_endobsname_tag + '|' + $
+                uvf_endobsname_tag)
               obs_names[i] = strmid(info_basename[0], 0, end_pos)
             endelse
             if n_infofile gt 1 then begin
@@ -471,37 +630,51 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
               fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
             endif
           endif else begin
-            if n_infofile gt 1 then message, 'More than one info file found with given obs_name'
+            if n_infofile gt 1 then begin
+              message, 'More than one info file found with given obs_name'
+            endif
             info_files[i] = info_file
             if stregex(info_basename[0], '[0-9]+', /boolean) then begin
               obs_names[i] = stregex(info_basename[0], '[0-9]+', /extract)
             endif else begin
-              end_pos = stregex(info_basename[0], hpx_endobsname_tag + '|' + uvf_endobsname_tag)
+              end_pos = stregex(info_basename[0], hpx_endobsname_tag + '|' + $
+                uvf_endobsname_tag)
               obs_names[i] = strmid(info_basename[0], 0, end_pos)
             endelse
-            test_other_obsnames = file_search(save_paths[i] + '*' + uvf_info_tag + '*info*', count = n_all_infofile)
-            if n_all_infofile gt n_infofile then fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
+            test_other_obsnames = file_search(save_paths[i] + '*' + uvf_info_tag + $
+              '*info*', count = n_all_infofile)
+            if n_all_infofile gt n_infofile then begin
+              fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
+            endif
           endelse
           integrated[i]=0
-          
+
         endif
       endelse
-      
+
       if not keyword_set(uvf_input) then begin
         ;; first look for integrated cube files in folder + data_dir with names like Combined_obs_...
         ;; if n_infofile > 1 then treat the one that's been chosen as exact to avoid multiple matches
         if keyword_set(exact_obsnames) or n_infofile gt 1 then begin
-          even_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '_even*_cube*.sav', count = n_even)
-          odd_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '_odd*_cube*.sav', count = n_odd)
+          even_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+            'Combined_obs_' + obs_names[i] + '_even*_cube*.sav', count = n_even)
+          odd_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+            'Combined_obs_' + obs_names[i] + '_odd*_cube*.sav', count = n_odd)
           if n_even gt 0 or n_odd gt 0 then begin
             cube_file_list = [even_file_list, odd_file_list]
             n_cubefiles = n_even + n_odd
-          endif else cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '_cube*.sav', count = n_cubefiles)
-        endif else cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '*_cube*.sav', count = n_cubefiles)
+          endif else begin
+            cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+            'Combined_obs_' + obs_names[i] + '_cube*.sav', count = n_cubefiles)
+          endelse
+        endif else begin
+          cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+            'Combined_obs_' + obs_names[i] + '*_cube*.sav', count = n_cubefiles)
+        endelse
         if n_cubefiles gt 0 then begin
           cube_basename = file_basename(cube_file_list)
           pol_exist = stregex(cube_basename, '[xy][xy]', /boolean, /fold_case)
-          
+
           if obs_names[i] eq '' then begin
             obs_name_arr = strarr(n_cubefiles)
             for j=0, n_cubefiles-1 do begin
@@ -511,17 +684,21 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
               end_pos_cube = strpos(strmid(cube_basename[j], start_pos), hpx_endobsname_tag) ;; always > -1
               end_pos = end_pos_even > end_pos_odd
               wh_noend = where(end_pos eq -1, count_noend)
-              if count_noend gt 0 then end_pos[wh_noend] = end_pos_cube[wh_noend]
-              
+              if count_noend gt 0 then begin
+                end_pos[wh_noend] = end_pos_cube[wh_noend]
+              endif
+
               ;obs_name_arr = stregex(cube_basename, '[0-9]+-[0-9]+', /extract)
               obs_name_arr[j] = strmid(cube_basename[j], start_pos, end_pos)
             endfor
-            
+
             wh_first = where(obs_name_arr eq obs_name_arr[0], count_first)
             if max(pol_exist[wh_first]) gt 0 then begin
-              if min(pol_exist[wh_first]) eq 0 then message, 'some files with first obs_name have pol identifiers and some do not'
+              if min(pol_exist[wh_first]) eq 0 then begin
+                message, 'some files with first obs_name have pol identifiers and some do not'
+              endif
               pols = stregex(cube_basename[wh_first], '[xy][xy]', /extract, /fold_case)
-              
+
               pols_inc = pols[0]
               pol_num = intarr(count_first)
               for pol_i=0, count_first-1 do begin
@@ -531,24 +708,33 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
                   pol_num[pol_i] = n_elements(pols_inc)-1
                 endelse
               endfor
-              
+
               for pol_i=0, n_elements(pols_inc) do begin
                 wh_pol = where(pol_num eq pol_i, count_pol)
-                if count_pol gt 2 then message, 'More than two cubes found with first obs_name and the same polarization'
+                if count_pol gt 2 then begin
+                  message, 'More than two cubes found with first obs_name and the same polarization'
+                endif
               endfor
-            endif else if count_first gt 2 then message, 'More than two cubes found with first obs_name'
-            
+            endif else begin
+              if count_first gt 2 then begin
+                message, 'More than two cubes found with first obs_name'
+              endif
+            endelse
+
             datafile = cube_file_list[wh_first]
             obs_names[i] = obs_name_arr[0]
             if count_first lt n_elements(cube_basename) then begin
-              print, 'More than one obs_name found, using first obs_name (' + obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
+              print, 'More than one obs_name found, using first obs_name (' + $
+                obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
               fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
             endif
           endif else begin
             if max(pol_exist) gt 0 then begin
-              if min(pol_exist) eq 0 then message, 'some files with given obs_name have pol identifiers and some do not'
+              if min(pol_exist) eq 0 then begin
+                message, 'some files with given obs_name have pol identifiers and some do not'
+              endif
               pols = stregex(cube_basename, '[xy][xy]', /extract, /fold_case)
-              
+
               pols_inc = pols[0]
               pol_num = intarr(n_cubefiles)
               for pol_i=0, n_cubefiles-1 do begin
@@ -558,13 +744,15 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
                   pol_num[pol_i] = n_elements(pols_inc)-1
                 endelse
               endfor
-              
+
               for pol_i=0, n_elements(pols_inc) do begin
                 wh_pol = where(pol_num eq pol_i, count_pol)
-                if count_pol gt 2 then message, 'More than two cubes found with given obs_name and the same polarization'
+                if count_pol gt 2 then begin
+                  message, 'More than two cubes found with given obs_name and the same polarization'
+                endif
               endfor
             endif else if n_cubefiles gt 2 then begin
-            
+
               ;; too many cubes with matching obs_name. Check to see what their whole obs_name is
               obs_name_arr = strarr(n_cubefiles)
               for j=0, n_cubefiles-1 do begin
@@ -574,48 +762,62 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
                 end_pos_cube = strpos(strmid(cube_basename[j], start_pos), hpx_endobsname_tag) ;; always > -1
                 end_pos = end_pos_even > end_pos_odd
                 wh_noend = where(end_pos eq -1, count_noend)
-                if count_noend gt 0 then end_pos[wh_noend] = end_pos_cube[wh_noend]
-                
+                if count_noend gt 0 then begin
+                  end_pos[wh_noend] = end_pos_cube[wh_noend]
+                endif
+
                 obs_name_arr[j] = strmid(cube_basename[j], start_pos, end_pos)
               endfor
-              
+
               wh_match = where(obs_name_arr eq obs_names[i], count_match)
               if count_match gt 0 then begin
-              
-                if count_match gt 2 then message, 'More than two cubes found with given obs_name'
+
+                if count_match gt 2 then begin
+                  message, 'More than two cubes found with given obs_name'
+                endif
                 cube_file_list = cube_file_list[wh_match]
               endif else begin
-              
+
                 wh_first = where(obs_name_arr eq obs_name_arr[0], count_first)
-                
+
                 if count_first le 2 then begin
-                  print, 'More than one obs_name found containing given obs_name (none match exactly), using first similar obs_name (' + obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
+                  print, 'More than one obs_name found containing given obs_name ' + $
+                    '(none match exactly), using first similar obs_name (' + $
+                      obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
                   cube_file_list = cube_file_list[wh_first]
                   obs_names[i] = obs_name_arr[0]
-                endif else message, 'More than two cubes found with given obs_name'
-                
+                endif else begin
+                  message, 'More than two cubes found with given obs_name'
+                endelse
               endelse
-              
+
             endif
-            
+
             datafile = cube_file_list
             if n_infofile eq 0 then begin
-              test_other_obsnames = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + '*_cube*.sav', count = n_all_infofile)
-              if n_all_infofile gt n_infofile then fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
+              test_other_obsnames = file_search(folder_names[i] + '/' + $
+                data_subdirs[i] + 'Combined_obs_' + '*_cube*.sav', count = n_all_infofile)
+              if n_all_infofile gt n_infofile then begin
+                fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
+              endif
             endif
           endelse
           integrated[i]=1
-          
+
         endif else begin
           ;; then look for single obs cube files
           if keyword_set(exact_obsnames) then begin
-            even_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '_even*_cube*.sav', count = n_even)
-            odd_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '_odd*_cube*.sav', count = n_odd)
+            even_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+              obs_names[i] + '_even*_cube*.sav', count = n_even)
+            odd_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+              obs_names[i] + '_odd*_cube*.sav', count = n_odd)
             if n_even gt 0 or n_odd gt 0 then begin
               cube_file_list = [even_file_list, odd_file_list]
               n_cubefiles = n_even + n_odd
-            endif else cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '_cube*.sav', count = n_cubefiles)
-          endif else cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_cube*.sav', count = n_cubefiles)
+            endif else cube_file_list = file_search(folder_names[i] + '/' + $
+              data_subdirs[i] + obs_names[i] + '_cube*.sav', count = n_cubefiles)
+          endif else cube_file_list = file_search(folder_names[i] + '/' + $
+            data_subdirs[i] + obs_names[i] + '*_cube*.sav', count = n_cubefiles)
           if n_cubefiles gt 0 then begin
             cube_basename = file_basename(cube_file_list)
             pol_exist = stregex(cube_basename, '[xy][xy]', /boolean, /fold_case)
@@ -627,17 +829,21 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
                 end_pos_cube = strpos(strmid(cube_basename[j], 0), hpx_endobsname_tag) ;; always > -1
                 end_pos = end_pos_even > end_pos_odd
                 wh_noend = where(end_pos eq -1, count_noend)
-                if count_noend gt 0 then end_pos[wh_noend] = end_pos_cube[wh_noend]
-                
+                if count_noend gt 0 then begin
+                  end_pos[wh_noend] = end_pos_cube[wh_noend]
+                endif
+
                 obs_name_arr[j] = strmid(cube_basename[j], 0, end_pos)
               endfor
               ;obs_name_arr = stregex(cube_basename, '[0-9]+', /extract)
-              
+
               wh_first = where(obs_name_arr eq obs_name_arr[0], count_first)
               if max(pol_exist[wh_first]) gt 0 then begin
-                if min(pol_exist[wh_first]) eq 0 then message, 'some files with first obs_name have pol identifiers and some do not'
+                if min(pol_exist[wh_first]) eq 0 then begin
+                  message, 'some files with first obs_name have pol identifiers and some do not'
+                endif
                 pols = stregex(cube_basename[wh_first], '[xy][xy]', /extract, /fold_case)
-                
+
                 pols_inc = pols[0]
                 pol_num = intarr(count_first)
                 for pol_i=0, count_first-1 do begin
@@ -647,27 +853,36 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
                     pol_num[pol_i] = n_elements(pols_inc)-1
                   endelse
                 endfor
-                
+
                 for pol_i=0, n_elements(pols_inc) do begin
                   wh_pol = where(pol_num eq pol_i, count_pol)
-                  if count_pol gt 2 then message, 'More than two cubes found with first obs_name and the same polarization'
+                  if count_pol gt 2 then begin
+                    message, 'More than two cubes found with first obs_name and the same polarization'
+                  endif
                 endfor
-              endif else if count_first gt 2 then message, 'More than two cubes found with first obs_name'
+              endif else begin
+                if count_first gt 2 then begin
+                  message, 'More than two cubes found with first obs_name'
+                endif
+              endelse
               datafile = cube_file_list[wh_first]
               obs_names[i] = obs_name_arr[0]
               integrated[i]=0
-              
+
               if count_first lt n_elements(cube_file_list) then begin
-                print, 'More than one obs_name found, using first obs_name (' + obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
+                print, 'More than one obs_name found, using first obs_name (' + $
+                  obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
                 fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
               endif
-              
+
             endif else begin
               ;; obsname not an empty string
               if max(pol_exist) gt 0 then begin
-                if min(pol_exist) eq 0 then message, 'some files with given obs_name have pol identifiers and some do not'
+                if min(pol_exist) eq 0 then begin
+                  message, 'some files with given obs_name have pol identifiers and some do not'
+                endif
                 pols = stregex(cube_basename, '[xy][xy]', /extract, /fold_case)
-                
+
                 pols_inc = pols[0]
                 pol_num = intarr(n_cubefiles)
                 for pol_i=0, n_cubefiles-1 do begin
@@ -677,38 +892,57 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
                     pol_num[pol_i] = n_elements(pols_inc)-1
                   endelse
                 endfor
-                
+
                 for pol_i=0, n_elements(pols_inc) do begin
                   wh_pol = where(pol_num eq pol_i, count_pol)
-                  if count_pol gt 2 then message, 'More than two cubes found with given obs_name and the same polarization'
+                  if count_pol gt 2 then begin
+                    message, 'More than two cubes found with given obs_name and the same polarization'
+                  endif
                 endfor
-              endif else if n_cubefiles gt 2 then message, 'More than two cubes found with given obs_name'
+              endif else begin
+                if n_cubefiles gt 2 then begin
+                  message, 'More than two cubes found with given obs_name'
+                endif
+              endelse
               datafile = cube_file_list
-              
-              test_other_obsnames = file_search(folder_names[i] + '/' + data_subdirs[i] + '*_cube*.sav', count = n_all_infofile)
-              if n_all_infofile gt n_infofile then fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
+
+              test_other_obsnames = file_search(folder_names[i] + '/' + $
+                data_subdirs[i] + '*_cube*.sav', count = n_all_infofile)
+              if n_all_infofile gt n_infofile then begin
+                fhd_types[i] = fhd_types[i] + '_' + obs_names[i]
+              endif
             endelse
           endif
-          
+
         endelse
       endif
-      
+
       if not (n_elements(info_file) gt 1 or not keyword_set(uvf_input)) then begin
         if n_elements(datafile) eq 0 then begin
           ;; finally look for uniformly gridded uvf files
           ;; Combined
           if keyword_set(exact_obsnames) then begin
-            even_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '_even*_uvf.sav', count = n_even)
-            odd_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '_odd*_uvf.sav', count = n_odd)
+            even_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+              'Combined_obs_' + obs_names[i] + '_even*_uvf.sav', count = n_even)
+            odd_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+              'Combined_obs_' + obs_names[i] + '_odd*_uvf.sav', count = n_odd)
             if n_even gt 0 or n_odd gt 0 then begin
               cube_file_list = [even_file_list, odd_file_list]
               n_cubefiles = n_even + n_odd
-            endif else cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '_gridded_uvf*.sav', count = n_cubefiles)
-          endif else cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '*_uvf.sav', count = n_cubefiles)
+            endif else begin
+              cube_file_list = file_search(folder_names[i] + '/' + $
+                data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '_gridded_uvf*.sav', $
+                count = n_cubefiles)
+            endelse
+          endif else begin
+            cube_file_list = file_search(folder_names[i] + '/' + $
+              data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '*_uvf.sav', $
+              count = n_cubefiles)
+          endelse
           if n_cubefiles gt 0 then begin
             cube_basename = file_basename(cube_file_list)
             pol_exist = stregex(cube_basename, '[xy][xy]', /boolean, /fold_case)
-            
+
             if obs_names[i] eq '' then begin
               obs_name_arr = strarr(n_cubefiles)
               for j=0, n_cubefiles-1 do begin
@@ -718,59 +952,78 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
                 end_pos_cube = strpos(strmid(cube_basename[j], start_pos), uvf_endobsname_tag) ;; always > -1
                 end_pos = end_pos_even > end_pos_odd
                 wh_noend = where(end_pos eq -1, count_noend)
-                if count_noend gt 0 then end_pos[wh_noend] = end_pos_cube[wh_noend]
-                
+                if count_noend gt 0 then begin
+                  end_pos[wh_noend] = end_pos_cube[wh_noend]
+                endif
+
                 ;obs_name_arr = stregex(cube_basename, '[0-9]+-[0-9]+', /extract)
                 obs_name_arr[j] = strmid(cube_basename[j], start_pos, end_pos)
               endfor
-              
+
               wh_first = where(obs_name_arr eq obs_name_arr[0], count_first)
               if max(pol_exist[wh_first]) gt 0 then begin
-                if min(pol_exist[wh_first]) eq 0 then message, 'some files with first obs_name have pol identifiers and some do not'
+                if min(pol_exist[wh_first]) eq 0 then begin
+                  message, 'some files with first obs_name have pol identifiers and some do not'
+                endif
                 pols = stregex(cube_basename[wh_first], '[xy][xy]', /extract, /fold_case)
-                
+
                 pols_inc = pols[0]
                 pol_num = intarr(count_first)
                 for pol_i=0, count_first-1 do begin
                   wh_pol = where(pols_inc eq pols[pol_i], count_pol)
-                  if count_pol eq 1 then pol_num[pol_i] = wh_pol[0] else begin
+                  if count_pol eq 1 then begin
+                    pol_num[pol_i] = wh_pol[0]
+                  endif else begin
                     pols_inc = [pols_inc, pols[pol_i]]
                     pol_num[pol_i] = n_elements(pols_inc)-1
                   endelse
                 endfor
-                
+
                 for pol_i=0, n_elements(pols_inc) do begin
                   wh_pol = where(pol_num eq pol_i, count_pol)
-                  if count_pol gt 2 then message, 'More than two cubes found with first obs_name and the same polarization'
+                  if count_pol gt 2 then begin
+                    message, 'More than two cubes found with first obs_name and the same polarization'
+                  endif
                 endfor
-              endif else if count_first gt 2 then message, 'More than two cubes found with first obs_name'
-              
-              if count_first lt n_elements(cube_basename) then $
-                print, 'More than one obs_name found, using first obs_name (' + obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
-                
+              endif else if count_first gt 2 then begin
+                message, 'More than two cubes found with first obs_name'
+              endif
+
+              if count_first lt n_elements(cube_basename) then begin
+                print, 'More than one obs_name found, using first obs_name (' + $
+                  obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
+              endif
               datafile = cube_file_list[wh_first]
               obs_names[i] = obs_name_arr[0]
             endif else begin
               if max(pol_exist) gt 0 then begin
-                if min(pol_exist) eq 0 then message, 'some files with given obs_name have pol identifiers and some do not'
+                if min(pol_exist) eq 0 then begin
+                  message, 'some files with given obs_name have pol identifiers and some do not'
+                endif
                 pols = stregex(cube_basename, '[xy][xy]', /extract, /fold_case)
-                
+
                 pols_inc = pols[0]
                 pol_num = intarr(n_cubefiles)
                 for pol_i=0, n_cubefiles-1 do begin
                   wh_pol = where(pols_inc eq pols[pol_i], count_pol)
-                  if count_pol eq 1 then pol_num[pol_i] = wh_pol[0] else begin
+                  if count_pol eq 1 then begin
+                    pol_num[pol_i] = wh_pol[0]
+                  endif else begin
                     pols_inc = [pols_inc, pols[pol_i]]
                     pol_num[pol_i] = n_elements(pols_inc)-1
                   endelse
                 endfor
-                
+
                 for pol_i=0, n_elements(pols_inc) do begin
                   wh_pol = where(pol_num eq pol_i, count_pol)
-                  if count_pol gt 2 then message, 'More than two cubes found with given obs_name and the same polarization'
+                  if count_pol gt 2 then begin
+                    message, 'More than two cubes found with given obs_name and the same polarization'
+                  endif
                 endfor
-              endif else if n_cubefiles gt 2 then message, 'More than two cubes found with given obs_name'
-              
+              endif else if n_cubefiles gt 2 then begin
+                message, 'More than two cubes found with given obs_name'
+              endif
+
               datafile = cube_file_list
             endelse
             integrated[i]=1
@@ -778,24 +1031,38 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
             uvf_input=1
             
             ;; look for beam files
-            beam_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + 'Combined_obs_' + obs_names[i] + '*gridded*beam2*image*.sav', count = n_beamfiles)
+            beam_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+              'Combined_obs_' + obs_names[i] + '*gridded*beam2*image*.sav', count = n_beamfiles)
             if n_beamfiles gt 0 then begin
               if n_elements(datafile) gt 1 then begin
-                if n_beamfiles eq 1 then beamfiles = strarr(n_elements(datafile)) + beam_file_list $
-                else if n_beamfiles ne n_elements(datafile) then stop
-              endif else if n_beamfiles ne n_elements(datafile) then stop
+                if n_beamfiles eq 1 then begin
+                  beamfiles = strarr(n_elements(datafile)) + beam_file_list
+                endif else begin
+                  if n_beamfiles ne n_elements(datafile) then stop
+                endelse
+              endif else begin
+                if n_beamfiles ne n_elements(datafile) then stop
+              endelse
             endif
-            
+
           endif else begin
             ;; single
             if keyword_set(exact_obsnames) then begin
-              even_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '_even*_uvf.sav', count = n_even)
-              odd_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '_odd*_uvf.sav', count = n_odd)
+              even_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+                obs_names[i] + '_even*_uvf.sav', count = n_even)
+              odd_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+                obs_names[i] + '_odd*_uvf.sav', count = n_odd)
               if n_even gt 0 or n_odd gt 0 then begin
                 cube_file_list = [even_file_list, odd_file_list]
                 n_cubefiles = n_even + n_odd
-              endif else cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '_gridded_uvf.sav', count = n_cubefiles)
-            endif else cube_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*_uvf.sav', count = n_cubefiles)
+              endif else begin
+                cube_file_list = file_search(folder_names[i] + '/' + $
+                  data_subdirs[i] + obs_names[i] + '_gridded_uvf.sav', count = n_cubefiles)
+              endelse
+            endif else begin
+              cube_file_list = file_search(folder_names[i] + '/' + $
+                data_subdirs[i] + obs_names[i] + '*_uvf.sav', count = n_cubefiles)
+            endelse
             if n_cubefiles gt 0 then begin
               cube_basename = file_basename(cube_file_list)
               pol_exist = stregex(cube_basename, '[xy][xy]', /boolean, /fold_case)
@@ -808,59 +1075,79 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
                   end_pos = end_pos_even > end_pos_odd
                   wh_noend = where(end_pos eq -1, count_noend)
                   if count_noend gt 0 then end_pos[wh_noend] = end_pos_cube[wh_noend]
-                  
+
                   obs_name_arr[j] = strmid(cube_basename[j], 0, end_pos)
                 endfor
                 ;obs_name_arr = stregex(cube_basename, '[0-9]+', /extract)
-                
+
                 wh_first = where(obs_name_arr eq obs_name_arr[0], count_first)
                 if max(pol_exist[wh_first]) gt 0 then begin
-                  if min(pol_exist[wh_first]) eq 0 then message, 'some files with first obs_name have pol identifiers and some do not'
+                  if min(pol_exist[wh_first]) eq 0 then begin
+                    message, 'some files with first obs_name have pol identifiers and some do not'
+                  endif
                   pols = stregex(cube_basename[wh_first], '[xy][xy]', /extract, /fold_case)
-                  
+
                   pols_inc = pols[0]
                   pol_num = intarr(count_first)
                   for pol_i=0, count_first-1 do begin
                     wh_pol = where(pols_inc eq pols[pol_i], count_pol)
-                    if count_pol eq 1 then pol_num[pol_i] = wh_pol[0] else begin
+                    if count_pol eq 1 then begin
+                      pol_num[pol_i] = wh_pol[0]
+                    endif else begin
                       pols_inc = [pols_inc, pols[pol_i]]
                       pol_num[pol_i] = n_elements(pols_inc)-1
                     endelse
                   endfor
-                  
+
                   for pol_i=0, n_elements(pols_inc) do begin
                     wh_pol = where(pol_num eq pol_i, count_pol)
-                    if count_pol gt 2 then message, 'More than two cubes found with first obs_name and the same polarization'
+                    if count_pol gt 2 then begin
+                      message, 'More than two cubes found with first obs_name and the same polarization'
+                    endif
                   endfor
-                endif else if count_first gt 2 then message, 'More than two cubes found with first obs_name'
-                
-                if count_first lt n_elements(cube_file_list) then $
-                  print, 'More than one obs_name found, using first obs_name (' + obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
-                  
+                endif else begin
+                  if count_first gt 2 then begin
+                    message, 'More than two cubes found with first obs_name'
+                  endif
+                endelse
+
+                if count_first lt n_elements(cube_file_list) then begin
+                  print, 'More than one obs_name found, using first obs_name (' + $
+                    obs_name_arr[0] + ', ' + number_formatter(count_first) + ' files)'
+                endif
+
                 datafile = cube_file_list[wh_first]
                 obs_names[i] = obs_name_arr[0]
                 integrated[i]=0
               endif else begin
                 if max(pol_exist) gt 0 then begin
-                  if min(pol_exist) eq 0 then message, 'some files with given obs_name have pol identifiers and some do not'
+                  if min(pol_exist) eq 0 then begin
+                    message, 'some files with given obs_name have pol identifiers and some do not'
+                  endif
                   pols = stregex(cube_basename, '[xy][xy]', /extract, /fold_case)
-                  
+
                   pols_inc = pols[0]
                   pol_num = intarr(n_cubefiles)
                   for pol_i=0, n_cubefiles-1 do begin
                     wh_pol = where(pols_inc eq pols[pol_i], count_pol)
-                    if count_pol eq 1 then pol_num[pol_i] = wh_pol[0] else begin
+                    if count_pol eq 1 then begin
+                      pol_num[pol_i] = wh_pol[0]
+                    endif else begin
                       pols_inc = [pols_inc, pols[pol_i]]
                       pol_num[pol_i] = n_elements(pols_inc)-1
                     endelse
                   endfor
-                  
+
                   for pol_i=0, n_elements(pols_inc) do begin
                     wh_pol = where(pol_num eq pol_i, count_pol)
-                    if count_pol gt 2 then message, 'More than two cubes found with given obs_name and the same polarization'
+                    if count_pol gt 2 then begin
+                      message, 'More than two cubes found with given obs_name and the same polarization'
+                    endif
                   endfor
-                endif else if n_cubefiles gt 2 then message, 'More than two cubes found with given obs_name'
-                
+                endif else if n_cubefiles gt 2 then begin
+                  message, 'More than two cubes found with given obs_name'
+                endif
+
                 datafile = cube_file_list
               endelse
             endif
@@ -868,49 +1155,75 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
             uvf_input=1
             
             ;; look for beam files
-            beam_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + obs_names[i] + '*gridded*beam2*image*.sav', count = n_beamfiles)
+            beam_file_list = file_search(folder_names[i] + '/' + data_subdirs[i] + $
+              obs_names[i] + '*gridded*beam2*image*.sav', count = n_beamfiles)
             if n_beamfiles gt 0 then begin
               if n_elements(datafile) gt 1 then begin
                 if n_beamfiles eq 1 then beamfiles = strarr(n_elements(datafile)) + beam_file_list[0] $
-                else if n_beamfiles ne n_elements(datafile) then stop else beamfiles = beam_file_list
-              endif else if n_beamfiles ne n_elements(datafile) then stop else beamfiles = beam_file_list
+                else if n_beamfiles ne n_elements(datafile) then begin
+                  stop
+                endif else begin
+                  beamfiles = beam_file_list
+                endelse
+              endif else begin
+                if n_beamfiles ne n_elements(datafile) then begin
+                  stop
+                endif else begin
+                  beamfiles = beam_file_list
+                endelse
+              endelse
             endif
-            
           endelse
         endif
       endif
-      
-      if n_elements(datafile) eq 0 and info_files[i] eq '' then message, 'No cube or info files found in folder ' + folder_names[i]
-      
+
+      if n_elements(datafile) eq 0 and info_files[i] eq '' then begin
+        message, 'No cube or info files found in folder ' + folder_names[i]
+      endif
+
       if n_elements(datafile) eq 0 then datafile = ''
-      if i eq 0 then cube_files = create_struct('fs0', datafile) else begin
+      if i eq 0 then begin
+        cube_files = create_struct('fs0', datafile)
+      endif else begin
         tag = 'fs' + number_formatter(i)
         cube_files = create_struct(cube_files, tag, datafile)
       endelse
       undefine, datafile
-      
+
     endfor
-    
-    obs_info = {folder_names:folder_names, folder_basenames:folder_basenames, obs_names:obs_names, info_files:info_files, cube_files:cube_files, $
+
+    obs_info = {folder_names:folder_names, folder_basenames:folder_basenames, $
+      obs_names:obs_names, info_files:info_files, cube_files:cube_files, $
       fhd_types:fhd_types, integrated:integrated, plot_paths:plot_paths, save_paths:save_paths}
-      
-    if n_filesets eq 2 then if ps_foldernames[0] ne ps_foldernames[1] then nominal_savepaths = folder_names + path_sep() + ps_foldernames $
+
+    if n_filesets eq 2 then begin
+      if ps_foldernames[0] ne ps_foldernames[1] then begin
+        nominal_savepaths = folder_names + path_sep() + ps_foldernames
+      endif
+    endif
     else nominal_savepaths = folder_names
     if n_elements(nominal_savepaths) eq 2 then begin
       folderparts_1 = strsplit(nominal_savepaths[0], path_sep(), /extract)
       folderparts_2 = strsplit(nominal_savepaths[1], path_sep(), /extract)
       match_test = strcmp(folderparts_1, folderparts_2)
-      wh_diff = where(match_test eq 0, count_diff, complement = wh_same, ncomplement = count_same)
-      
-      fhdtypeparts_1 = strsplit(file_basename(fhd_types[0]), '_', /extract, count = nfhdtypeparts_1)
-      fhdtypeparts_2 = strsplit(file_basename(fhd_types[1]), '_', /extract, count = nfhdtypeparts_2)
+      wh_diff = where(match_test eq 0, count_diff, complement = wh_same, $
+        ncomplement = count_same)
+
+      fhdtypeparts_1 = strsplit(file_basename(fhd_types[0]), '_', /extract, $
+        count = nfhdtypeparts_1)
+      fhdtypeparts_2 = strsplit(file_basename(fhd_types[1]), '_', /extract, $
+        count = nfhdtypeparts_2)
       if nfhdtypeparts_1 ne nfhdtypeparts_2 then begin
-        if nfhdtypeparts_1 gt nfhdtypeparts_2 then fhdtypeparts_2 = [fhdtypeparts_2, strarr(nfhdtypeparts_1-nfhdtypeparts_2)] $
-        else fhdtypeparts_1 = [fhdtypeparts_1, strarr(nfhdtypeparts_2-nfhdtypeparts_1)]
+        if nfhdtypeparts_1 gt nfhdtypeparts_2 then begin
+          fhdtypeparts_2 = [fhdtypeparts_2, strarr(nfhdtypeparts_1-nfhdtypeparts_2)]
+        endif else begin
+          fhdtypeparts_1 = [fhdtypeparts_1, strarr(nfhdtypeparts_2-nfhdtypeparts_1)]
+        endelse
       endif
       match_fhdtype_test = strcmp(fhdtypeparts_1, fhdtypeparts_2)
-      wh_fhdtype_diff = where(match_fhdtype_test eq 0, count_fhdtype_diff, complement = wh_fhdtype_same, ncomplement = count_fhdtype_same)
-      
+      wh_fhdtype_diff = where(match_fhdtype_test eq 0, count_fhdtype_diff, $
+        complement = wh_fhdtype_same, ncomplement = count_fhdtype_same)
+
       if count_fhdtype_diff gt 0 then begin
         if min(wh_fhdtype_diff) ge nfhdtypeparts_1 or min(wh_fhdtype_diff) ge nfhdtypeparts_2 then begin
           wh_fhdtype_diff = [max(wh_fhdtype_same), wh_fhdtype_diff]
@@ -918,42 +1231,66 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
           if count_fhdtype_same gt 1 then begin
             wh_fhdtype_same = wh_fhdtype_same[0:count_fhdtype_same-2]
             count_fhdtype_same = count_fhdtype_same-1
-          endif else count_fhdtype_same = 0
+          endif else begin
+            count_fhdtype_same = 0
+          endelse
         endif
-        
+
         str1_diff_fhdtype = strjoin(fhdtypeparts_1[wh_fhdtype_diff[where((wh_fhdtype_diff lt nfhdtypeparts_1) gt 0)]], '_')
         str2_diff_fhdtype = strjoin(fhdtypeparts_2[wh_fhdtype_diff[where((wh_fhdtype_diff lt nfhdtypeparts_2) gt 0)]], '_')
-        
-        if count_fhdtype_same gt 0 then fhdtype_same_parts = strjoin(fhdtypeparts_1[wh_fhdtype_same], '_') else fhdtype_same_parts = ''
-        if count_fhdtype_diff eq 0 then fhdtype_diff_parts = strarr(2) else fhdtype_diff_parts = [str1_diff_fhdtype, str2_diff_fhdtype]
+
+        if count_fhdtype_same gt 0 then begin
+          fhdtype_same_parts = strjoin(fhdtypeparts_1[wh_fhdtype_same], '_')
+        endif else begin
+          fhdtype_same_parts = ''
+        endelse
+        if count_fhdtype_diff eq 0 then begin
+          fhdtype_diff_parts = strarr(2)
+        endif else begin
+            fhdtype_diff_parts = [str1_diff_fhdtype, str2_diff_fhdtype]
+        endelse
       endif
-      
+
       if count_diff eq 0 then begin
         ;; folders are the same
-        if obs_info.obs_names[0] eq obs_info.obs_names[1] then diff_note = obs_info.fhd_types[0] $
-        else diff_note = nominal_savepaths[0] + ' ' + obs_info.obs_names[0] + '-' + obs_info.obs_names[1]
+        if obs_info.obs_names[0] eq obs_info.obs_names[1] then begin
+          diff_note = obs_info.fhd_types[0]
+        endif else begin
+          diff_note = nominal_savepaths[0] + ' ' + obs_info.obs_names[0] + '-' + obs_info.obs_names[1]
+        endelse
         diff_save_path = nominal_savepaths[0] + path_sep()
       endif else begin
         joint_path = strjoin(folderparts_1[wh_same], path_sep())
-        if strmid(nominal_savepaths[0], 0,1) eq path_sep() then joint_path = path_sep() + joint_path
-        
-        
+        if strmid(nominal_savepaths[0], 0,1) eq path_sep() then begin
+          joint_path = path_sep() + joint_path
+        endif
+
         fnameparts_1 = strsplit(file_basename(nominal_savepaths[0]), '_', /extract, count = nfileparts_1)
         fnameparts_2 = strsplit(file_basename(nominal_savepaths[1]), '_', /extract, count = nfileparts_2)
         if nfileparts_1 ne nfileparts_2 then begin
-          if nfileparts_1 gt nfileparts_2 then fnameparts_2 = [fnameparts_2, strarr(nfileparts_1-nfileparts_2)] $
-          else fnameparts_1 = [fnameparts_1, strarr(nfileparts_2-nfileparts_1)]
+          if nfileparts_1 gt nfileparts_2 then begin
+            fnameparts_2 = [fnameparts_2, strarr(nfileparts_1-nfileparts_2)]
+          endif else begin
+            fnameparts_1 = [fnameparts_1, strarr(nfileparts_2-nfileparts_1)]
+          endelse
         endif
         match_name_test = strcmp(fnameparts_1, fnameparts_2)
-        wh_name_diff = where(match_name_test eq 0, count_name_diff, complement = wh_name_same, ncomplement = count_name_same)
-        
+        wh_name_diff = where(match_name_test eq 0, count_name_diff, $
+          complement = wh_name_same, ncomplement = count_name_same)
+
         if count_name_diff eq 0 then begin
           ;; same folder name, different directories
           diff_dir = file_basename(nominal_savepaths[0]) + '_diff'
-          if count_fhdtype_diff eq 0 then diff_note = strjoin(folderparts_1[wh_diff], path_sep()) + ' - ' + strjoin(folderparts_2[wh_diff], path_sep()) + ' ' + file_basename(nominal_savepaths[0]) $
-          else $
-            diff_note = strjoin(folderparts_1[wh_diff], path_sep()) + strjoin(fhdtypeparts_1[wh_fhdtype_diff], '_') + ' - ' + $
-            strjoin(folderparts_2[wh_diff], path_sep()) + strjoin(fhdtypeparts_2[wh_fhdtype_diff], '_') + ' ' + file_basename(nominal_savepaths[0])
+          if count_fhdtype_diff eq 0 then  begin
+            diff_note = strjoin(folderparts_1[wh_diff], path_sep()) + ' - ' + $
+              strjoin(folderparts_2[wh_diff], path_sep()) + ' ' + file_basename(nominal_savepaths[0])
+          endif else begin
+            diff_note = strjoin(folderparts_1[wh_diff], path_sep()) + $
+              strjoin(fhdtypeparts_1[wh_fhdtype_diff], '_') + ' - ' + $
+              strjoin(folderparts_2[wh_diff], path_sep()) + $
+              strjoin(fhdtypeparts_2[wh_fhdtype_diff], '_') + ' ' + $
+              file_basename(nominal_savepaths[0])
+          endelse
         endif else begin
           if min(wh_name_diff) ge nfileparts_1 or min(wh_name_diff) ge nfileparts_2 then begin
             wh_name_diff = [max(wh_name_same), wh_name_diff]
@@ -961,12 +1298,14 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
             if count_name_same gt 1 then begin
               wh_name_same = wh_name_same[0:count_name_same-2]
               count_name_same = count_name_same-1
-            endif else count_name_same = 0
+            endif else begin
+              count_name_same = 0
+            endelse
           endif
-          
+
           str1_diff = strjoin(fnameparts_1[wh_name_diff[where((wh_name_diff lt nfileparts_1) gt 0)]], '_')
           str2_diff = strjoin(fnameparts_2[wh_name_diff[where((wh_name_diff lt nfileparts_2) gt 0)]], '_')
-          
+
           if count_name_same gt 0 then begin
             str_same = strjoin(fnameparts_1[wh_name_same], '_')
             diff_dir = str_same + '__' + str1_diff + '_minus_' + str2_diff
@@ -976,31 +1315,52 @@ function ps_filenames, folder_names, obs_names_in, dirty_folder = dirty_folder, 
             diff_note = str1_diff + ' - ' + str2_diff
           endelse
         endelse
-        
+
         diff_save_path = joint_path + path_sep() + diff_dir + path_sep()
-        
-        if count_name_same gt 0 then name_same_parts = strjoin(fnameparts_1[wh_name_same], '_') else name_same_parts = ''
-        if count_name_diff eq 0 then name_diff_parts = strarr(2) else name_diff_parts = [str1_diff, str2_diff]
-        
+
+        if count_name_same gt 0 then begin
+          name_same_parts = strjoin(fnameparts_1[wh_name_same], '_')
+        endif else begin
+          name_same_parts = ''
+        endelse
+        if count_name_diff eq 0 then begin
+          name_diff_parts = strarr(2)
+        endif else begin
+          name_diff_parts = [str1_diff, str2_diff]
+        endelse
       endelse
-      
+
     endif
-    
-    if n_elements(diff_save_path) gt 0 then diff_plot_path = diff_save_path + 'plots' + path_sep()
-    if n_elements(diff_note) gt 0 then obs_info = create_struct(obs_info, 'diff_note', diff_note, 'diff_save_path', $
-      diff_save_path, 'diff_plot_path', diff_plot_path)
-      
-    if n_elements(name_same_parts) gt 0 then obs_info = create_struct(obs_info, 'name_same_parts', name_same_parts, 'name_diff_parts',name_diff_parts)
-    
-    if n_elements(fhdtype_same_parts) gt 0 then obs_info = create_struct(obs_info, 'fhdtype_same_parts', fhdtype_same_parts, 'fhdtype_diff_parts',fhdtype_diff_parts)
-    
-    
-    if n_elements(uvf_input) gt 0 then obs_info = create_struct(obs_info, 'uvf_input', uvf_input)
-    
-    if n_elements(beamfiles) gt 0 then obs_info = create_struct(obs_info, 'beam_files', beamfiles)
-    
+
+    if n_elements(diff_save_path) gt 0 then begin
+      diff_plot_path = diff_save_path + 'plots' + path_sep()
+    endif
+    if n_elements(diff_note) gt 0 then begin
+      obs_info = create_struct(obs_info, 'diff_note', diff_note, 'diff_save_path', $
+        diff_save_path, 'diff_plot_path', diff_plot_path)
+    endif
+
+    if n_elements(name_same_parts) gt 0 then begin
+      obs_info = create_struct(obs_info, 'name_same_parts', name_same_parts, $
+        'name_diff_parts',name_diff_parts)
+      endif
+
+    if n_elements(fhdtype_same_parts) gt 0 then begin
+      obs_info = create_struct(obs_info, 'fhdtype_same_parts', fhdtype_same_parts, $
+        'fhdtype_diff_parts',fhdtype_diff_parts)
+      endif
+
+
+    if n_elements(uvf_input) gt 0 then begin
+      obs_info = create_struct(obs_info, 'uvf_input', uvf_input)
+    endif
+
+    if n_elements(beamfiles) gt 0 then begin
+      obs_info = create_struct(obs_info, 'beam_files', beamfiles)
+    endif
+
   endelse
-  
+
   return, obs_info
-  
+
 end


### PR DESCRIPTION
This branch reorganizes the output of eppsilon into the following folders:
* ps
  * data
    * uvf_cubes
         * slices
    * kspace_cubes
       * slices
     * beams
     * 2d_binning
       * from_1d
     * 1d_binning (includes kperp/kpar files & kpar=0 files)

  * plots
    * slices
    * 2d_binning
      * from_1d
    * 1d_binning
      * bin_histograms

It is not yet backwards compatible, I have some questions about what users want for backwards compatibility. I think there are two options:
1. When eppsilon is called on an old folder it can reorganize that folder according to this structure. If we do this, the easiest implementation will only move the files associated with the run it's called for, so if there are files generated by runs using different keyword settings, those files would not be moved until eppsilon is re-run with those settings. If this is terrible, I can try to write something that generally moves all the files, but it'll be harder. Also, I wonder whether the existing plot files should just all be deleted (since they are re-created on each run) or whether I should test for and delete only the plotfiles associated with the run it's called for.
1. When eppsilon is called on an old folder it just leaves the existing files in place and only writes new files (and plots) to the new structure.

I'd like to get feedback from users about which of these options they prefer.
@adampbeardsley @nicholebarry @rlbyrne @mkolopanis