### PR TITLE
Odd freq fix

### DIFF
--- a/ps_core/kspace_rebinning_2d.pro
+++ b/ps_core/kspace_rebinning_2d.pro
@@ -302,14 +302,7 @@ function kspace_rebinning_2d, power_3d, kx_mpc, ky_mpc, kz_mpc, kperp_edges_mpc,
 
   undefine, reformed_power, reformed_nev, reformed_wtpower, reformed_wtnev, reformed_weights
 
-  kpar_centers_mpc = kz_mpc
-  kz_delta = kz_mpc[1] - kz_mpc[0]
   if not binning_2d_options.log_kpar then begin
-
-    ;; kpar_edges_mpc = [kz_mpc[0] - kz_delta/2d, kz_mpc + kz_delta/2d]
-
-    ;; weighted_power_2d = temporary(weighted_power_mid)
-    ;; weights_2d = temporary(weights_mid)
 
     if keyword_set(edge_on_grid) then begin
       kpar_min = floor(min(kz_mpc) / binning_2d_options.kpar_bin) * binning_2d_options.kpar_bin

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -42,11 +42,12 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   z_mpc_length = max(comov_dist_los) - min(comov_dist_los) + z_mpc_delta
   kz_mpc_range =  (2.*!pi) / (z_mpc_delta)
   kz_mpc_delta = (2.*!pi) / z_mpc_length
-  kz_mpc_orig = findgen(round(kz_mpc_range / kz_mpc_delta)) * kz_mpc_delta - kz_mpc_range/2.
-  if n_elements(n_kz) ne 0 then begin
-    if n_elements(kz_mpc_orig) ne n_kz then message, $
-      'something has gone wrong with kz_mpc calculation.'
-  endif else n_kz = n_elements(kz_mpc_orig)
+  ;; calculate this way to be correct for even or odd numbers of frequencies
+  min_kz = floor((kz_mpc_range/2)/kz_mpc_delta)*kz_mpc_delta
+  kz_mpc_orig = findgen(round(kz_mpc_range / kz_mpc_delta)) * kz_mpc_delta - min_kz
+
+  n_kz = n_elements(kz_mpc_orig)
+  if n_kz ne n_freq then message, 'something has gone wrong with kz_mpc calculation.'
 
   if input_units eq 'jansky' then begin
     ;; converting from Jy (in u,v,f) to mK*str (10^-26 * c^2 * 10^3/ (2*f^2*kb))


### PR DESCRIPTION
Fix an bug in how k parallel values are calculated for an odd number of frequencies that lead to ugly horizontal striping in the 2d power spectrum plots.