### PR TITLE
Ave remove fix

### DIFF
--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1282,11 +1282,14 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   if tag_exist(ps_options, 'spec_window_type') then begin
     window = spectral_window(n_freq, type = ps_options.spec_window_type, /periodic)
 
+    ;; this is the equivilent bandwidth reduction (approx. 2 for blackman-harris)
     norm_factor = sqrt(n_freq/total(window^2.))
 
     window = window * norm_factor
 
     if ps_options.ave_removal then begin
+      ;; need to divide by bandwidth factor to account for the
+      ;; reduction in the mean that should happen when the window is applied
       data_sum_mean = data_sum_mean / norm_factor
       sim_noise_sum_mean = sim_noise_sum_mean / norm_factor
       data_diff_mean = data_diff_mean / norm_factor

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1258,7 +1258,6 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   else uv_slice2 = uv_slice
   undefine, uv_slice
 
-
   if ps_options.ave_removal then begin
 
     data_sum_mean = mean(data_sum, dimension=3)
@@ -1286,6 +1285,13 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
     norm_factor = sqrt(n_freq/total(window^2.))
 
     window = window * norm_factor
+
+    if ps_options.ave_removal then begin
+      data_sum_mean = data_sum_mean / norm_factor
+      sim_noise_sum_mean = sim_noise_sum_mean / norm_factor
+      data_diff_mean = data_diff_mean / norm_factor
+      sim_noise_diff_mean = sim_noise_diff_mean / norm_factor
+    endif
 
     window_expand = rebin(reform(window, 1, 1, n_freq), n_kx, n_ky, n_freq, /sample)
 


### PR DESCRIPTION
Fix the normalization of the k parallel = 0 bin when `ave_removal` is used with a spectral window function.

fixes #63