### PR TITLE
Add image_clip option, default to using the full image is used with the standard uv pixel size

### DIFF
--- a/ps_core/ps_main_plots.pro
+++ b/ps_core/ps_main_plots.pro
@@ -277,6 +277,8 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
     endif
   endfor
 
+  kperp_lambda_conv = getvar_savefile(file_struct_arr[0].power_savefile, 'kperp_lambda_conv')
+
   ;; setup for saving plots
   power_tag = file_struct_arr[0].power_tag
   if tag_exist(file_struct_arr[0], 'uvf_tag') then begin
@@ -386,6 +388,36 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
     endelse
   endif
 
+  if tag_exist(plot_2d_options, 'kperp_lambda_plot_range') and $
+    not tag_exist(plot_2d_options, 'kperp_plot_range') then begin
+
+    kperp_plot_range = plot_2d_options.kperp_lambda_plot_range / kperp_lambda_conv
+
+    ;; if we're plotting in [k]=h/Mpc then need to convert from 1/Mpc
+    if plot_options.hinv then kperp_plot_range = kperp_plot_range / hubble_param
+
+    plot_2d_options = create_plot_2d_options(plot_2d_options = plot_2d_options, $
+      kperp_plot_range = kperp_plot_range)
+  endif
+
+  if not tag_exist(plot_2d_options, 'kperp_plot_range') then begin
+    if tag_exist(uvf_options, 'max_uv_lambda') gt 0 then begin
+      max_kperp_lambda = min([uvf_options.max_uv_lambda, $
+                              min(file_struct_arr.kspan/2.), $
+                              min(file_struct_arr.max_baseline_lambda)])
+    endif else begin
+      max_kperp_lambda = min([file_struct_arr.kspan/2.,file_struct_arr.max_baseline_lambda])
+    endelse
+    kperp_plot_range = [7.5/kperp_lambda_conv, max_kperp_lambda/kperp_lambda_conv]
+
+    ;; if we're plotting in [k]=h/Mpc then need to convert from 1/Mpc
+    if plot_options.hinv then kperp_plot_range = kperp_plot_range / hubble_param
+
+    plot_2d_options = create_plot_2d_options(plot_2d_options = plot_2d_options, $
+      kperp_plot_range = kperp_plot_range)
+  endif
+
+
   window_num=0
 
   ;; Now set up slice stuff
@@ -409,7 +441,6 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
 
       slice_plotfile_base = plotfile_path + file_struct_arr[0].subfolders.slices + $
         plotfile_base + '_' + plot_types.slice_type
-      slice_plotfile_end = plot_fadd + plot_options.plot_exten
       if plot_options.individual_plots then begin
 
         indv_plotfile_base = plotfile_path + file_struct_arr[0].subfolders.slices + $
@@ -1320,35 +1351,6 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
   if not tag_exist(binning_2d_options, 'kperp_bin') then begin
     binning_2d_options = create_binning_2d_options(binning_2d_options = binning_2d_options, $
       kperp_bin = kperp_bin)
-  endif
-
-  if tag_exist(plot_2d_options, 'kperp_lambda_plot_range') and $
-    not tag_exist(plot_2d_options, 'kperp_plot_range') then begin
-
-    kperp_plot_range = plot_2d_options.kperp_lambda_plot_range / kperp_lambda_conv
-
-    ;; if we're plotting in [k]=h/Mpc then need to convert from 1/Mpc
-    if plot_options.hinv then kperp_plot_range = kperp_plot_range / hubble_param
-
-    plot_2d_options = create_plot_2d_options(plot_2d_options = plot_2d_options, $
-      kperp_plot_range = kperp_plot_range)
-  endif
-
-  if not tag_exist(plot_2d_options, 'kperp_plot_range') then begin
-    if tag_exist(uvf_options, 'max_uv_lambda') gt 0 then begin
-      max_kperp_lambda = min([uvf_options.max_uv_lambda, $
-                              min(file_struct_arr.kspan/2.), $
-                              min(file_struct_arr.max_baseline_lambda)])
-    endif else begin
-      max_kperp_lambda = min([file_struct_arr.kspan/2.,file_struct_arr.max_baseline_lambda])
-    endelse
-    kperp_plot_range = [7.5/kperp_lambda_conv, max_kperp_lambda/kperp_lambda_conv]
-
-    ;; if we're plotting in [k]=h/Mpc then need to convert from 1/Mpc
-    if plot_options.hinv then kperp_plot_range = kperp_plot_range / hubble_param
-
-    plot_2d_options = create_plot_2d_options(plot_2d_options = plot_2d_options, $
-      kperp_plot_range = kperp_plot_range)
   endif
 
   if plot_options.pub then begin

--- a/ps_core/ps_main_plots.pro
+++ b/ps_core/ps_main_plots.pro
@@ -1342,7 +1342,7 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
     endif else begin
       max_kperp_lambda = min([file_struct_arr.kspan/2.,file_struct_arr.max_baseline_lambda])
     endelse
-    kperp_plot_range = [5./kperp_lambda_conv, max_kperp_lambda/kperp_lambda_conv]
+    kperp_plot_range = [7.5/kperp_lambda_conv, max_kperp_lambda/kperp_lambda_conv]
 
     ;; if we're plotting in [k]=h/Mpc then need to convert from 1/Mpc
     if plot_options.hinv then kperp_plot_range = kperp_plot_range / hubble_param

--- a/ps_setup/create_file_tags.pro
+++ b/ps_setup/create_file_tags.pro
@@ -48,6 +48,9 @@ function create_file_tags, freq_ch_range = freq_ch_range, freq_flags = freq_flag
   if uvf_options.full_image then begin
     uv_tag = uv_tag + '_fullimg'
   endif
+  if not uvf_options.image_clip then begin
+    uv_tag = uv_tag + '_noimgclip'
+  endif
   if tag_exist(uvf_options, 'max_uv_lambda') then begin
     uv_tag = uv_tag + '_maxuv' + number_formatter(uvf_options.max_uv_lambda)
   endif

--- a/ps_setup/create_uvf_options.pro
+++ b/ps_setup/create_uvf_options.pro
@@ -1,6 +1,7 @@
 function create_uvf_options, uvf_options = uvf_options, $
     delta_uv_lambda = delta_uv_lambda, max_uv_lambda = max_uv_lambda, $
-    full_image = full_image, uv_avg = uv_avg, uv_img_clip = uv_img_clip, $
+    full_image = full_image, image_clip = image_clip, $
+    uv_avg = uv_avg, uv_img_clip = uv_img_clip, $
     require_radec = require_radec, dft_fchunk = dft_fchunk, $
     no_dft_progress = no_dft_progress, return_new = return_new
 
@@ -14,14 +15,17 @@ function create_uvf_options, uvf_options = uvf_options, $
     ;; default to giving dft progress reports
     if n_elements(no_dft_progress) eq 0 then no_dft_progress = 0
 
-    ;; default to not using full images
+    ;; default to not using full image to set the uv cell size
     if n_elements(full_image) eq 0 then full_image = 0
 
     ;; default to not requiring radec
     if n_elements(require_radec) eq 0 then require_radec = 0
 
+    ;; default to not clipping the image (use the full image but with the standard uv pixel size)
+    if n_elements(image_clip) eq 0 then image_clip = 0
+
     uvf_options = {no_dft_progress: no_dft_progress, full_image: full_image, $
-                   require_radec: require_radec}
+                   require_radec: require_radec, image_clip: image_clip}
   endif else begin
     if n_elements(no_dft_progress) gt 0 then begin
       update_tags.add, 'no_dft_progress'

--- a/ps_utils/choose_pix_ft.pro
+++ b/ps_utils/choose_pix_ft.pro
@@ -118,20 +118,25 @@ function choose_pix_ft, file_struct, pixel_nums = pixel_nums, data_dims = data_d
     max_kperp_rad = min([max_kperp_rad, uvf_options.max_uv_lambda * (2.*!pi)])
   endif
 
-  ;; limit field of view to match calculated k-modes
-  xy_len = 2*!pi/delta_kperp_rad
+  ;; calculate the image size that corresponds to the uv spacing
+  xy_len_matched = 2*!pi/delta_kperp_rad
 
-  ;; image may be smaller than expected, may need to adjust delta_kperp_rad
-  if image_len lt xy_len then begin
-    print, 'Image FoV is smaller than expected, increasing delta kperp to match image FoV'
-    delta_kperp_rad = 2*!pi/image_len
+  ;; clip window to a square (and optionally to match delta kperp)
+  if uvf_options.image_clip and xy_len_matched lt image_len then begin
+    ;; limit field of view to match delta kperp
+    print, 'Image FoV is larger than expected given delta kperp and ' + $
+      'image_clip is set. Clipping image to match delta kperp.'
+    x_range = [-1,1]*xy_len_matched/2. + mean(x_rot)
+    y_range = [-1,1]*xy_len_matched/2. + mean(y_rot)
+  endif else begin
+
+    if image_len lt xy_len_matched then begin
+      print, 'Image FoV is smaller than expected, increasing delta kperp to match image FoV'
+      delta_kperp_rad = 2*!pi/image_len
+    endif
 
     x_range = [-1,1]*image_len/2. + mean(x_rot)
     y_range = [-1,1]*image_len/2. + mean(y_rot)
-
-  endif else begin
-    x_range = [-1,1]*xy_len/2. + mean(x_rot)
-    y_range = [-1,1]*xy_len/2. + mean(y_rot)
   endelse
 
   wh_close = where(x_rot le x_range[1] and x_rot ge x_range[0] and $

--- a/ps_utils/choose_pix_ft.pro
+++ b/ps_utils/choose_pix_ft.pro
@@ -86,7 +86,13 @@ function choose_pix_ft, file_struct, pixel_nums = pixel_nums, data_dims = data_d
   endif
 
   ;; figure out k values to calculate dft
-  uv_cellsize_m = 5 ;; based on calculations of beam FWHM by Aaron
+  uv_cellsize_m = 5 ;; based on calculations of beam FWHM by Aaron Ewall-Wice
+
+  ;; Cannot set full_image with image_clip=0 error if this is the case.
+  if uvf_options.full_image gt 0 and uvf_options.image_clip eq 0 then begin
+    message, 'If full_image is set, image_clip cannot be set to 0.'
+  endif
+  
   if uvf_options.full_image then begin
     ;; use the full image size.
 

--- a/ps_wrappers/ps_diff_wrapper.pro
+++ b/ps_wrappers/ps_diff_wrapper.pro
@@ -2,7 +2,7 @@ pro ps_diff_wrapper, folder_names_in, obs_names_in, ps_foldernames = ps_folderna
     version_test = version_test, $
     cube_types = cube_types, pols = pols,  refresh_diff = refresh_diff, $
     spec_window_types = spec_window_types, delta_uv_lambda = delta_uv_lambda, $
-    max_uv_lambda = max_uv_lambda, full_image = full_image, $
+    max_uv_lambda = max_uv_lambda, full_image = full_image, image_clip = image_clip, $
     ave_removal = ave_removal, $
     all_type_pol = all_type_pol, freq_ch_range = freq_ch_range, $
     plot_slices = plot_slices, slice_type = slice_type, $
@@ -62,10 +62,11 @@ pro ps_diff_wrapper, folder_names_in, obs_names_in, ps_foldernames = ps_folderna
 
   if n_elements(delta_uv_lambda) gt 1 then message, 'only 1 delta_uv_lambda allowed'
 
-  if n_elements(max_uv_lambda) lt 2 and n_elements(full_image) lt 2 then begin
+  if n_elements(max_uv_lambda) lt 2 and n_elements(full_image) lt 2 $
+     and n_elements(image_clip) lt 2 then begin
 
     uvf_options0 = create_uvf_options(delta_uv_lambda = delta_uv_lambda, $
-      max_uv_lambda = max_uv_lambda, full_image = full_image)
+      max_uv_lambda = max_uv_lambda, full_image = full_image, image_clip = image_clip)
 
   endif else begin
     case n_elements(max_uv_lambda) of
@@ -91,13 +92,25 @@ pro ps_diff_wrapper, folder_names_in, obs_names_in, ps_foldernames = ps_folderna
         fi0 = full_image[0]
         fi1 = full_image[1]
       end
-      else: message, 'only 1 or 2 full_image values allowed'
+    endcase
+
+    case n_elements(image_clip) of
+        0:
+        1: begin
+          ic0 = image_clip
+          ic1 = image_clip
+        end
+        2: begin
+          ic0 = image_clip[0]
+          ic1 = image_clip[1]
+        end
+      else: message, 'only 1 or 2 image_clip values allowed'
     endcase
 
     uvf_options0 = create_uvf_options(delta_uv_lambda = delta_uv_lambda, $
-      max_uv_lambda = mul0, full_image = fi0)
+      max_uv_lambda = mul0, full_image = fi0, image_clip = ic0)
     uvf_options1 = create_uvf_options(delta_uv_lambda = delta_uv_lambda, $
-      max_uv_lambda = mul1, full_image = fi1)
+      max_uv_lambda = mul1, full_image = fi1, image_clip = ic1)
   endelse
 
   if n_elements(ave_removal) lt 2 and n_elements(wt_cutoffs) lt 2 and $

--- a/ps_wrappers/ps_ratio_wrapper.pro
+++ b/ps_wrappers/ps_ratio_wrapper.pro
@@ -2,7 +2,8 @@ pro ps_ratio_wrapper, folder_names_in, obs_names_in, ps_foldernames=ps_foldernam
     exact_obsnames = exact_obsnames,  cube_types = cube_types,  pols = pols, $
     all_pol_diff_ratio = all_pol_diff_ratio, freq_ch_range = freq_ch_range, $
     spec_window_types = spec_window_types, delta_uv_lambda = delta_uv_lambda, $
-    full_image = full_image, ave_removal = ave_removal, diff_ratio = diff_ratio, $
+    full_image = full_image, image_clip = image_clip, $
+    ave_removal = ave_removal, diff_ratio = diff_ratio, $
     diff_range = diff_range, png = png, eps = eps, pdf = pdf, $
     data_range = data_range, $
     color_type = color_type, invert_colorbar = invert_colorbar, $
@@ -46,10 +47,11 @@ pro ps_ratio_wrapper, folder_names_in, obs_names_in, ps_foldernames=ps_foldernam
 
   if n_elements(delta_uv_lambda) gt 1 then message, 'only 1 delta_uv_lambda allowed'
 
-  if n_elements(max_uv_lambda) lt 2 and n_elements(full_image) lt 2 then begin
+  if n_elements(max_uv_lambda) lt 2 and n_elements(full_image) lt 2 $
+     and n_elements(image_clip) lt 2 then begin
 
     uvf_options0 = create_uvf_options(delta_uv_lambda = delta_uv_lambda, $
-      max_uv_lambda = max_uv_lambda, full_image = full_image)
+      max_uv_lambda = max_uv_lambda, full_image = full_image, image_clip = image_clip)
 
   endif else begin
     case n_elements(max_uv_lambda) of
@@ -78,10 +80,23 @@ pro ps_ratio_wrapper, folder_names_in, obs_names_in, ps_foldernames=ps_foldernam
       else: message, 'only 1 or 2 full_image values allowed'
     endcase
 
+    case n_elements(image_clip) of
+        0:
+        1: begin
+          ic0 = image_clip
+          ic1 = image_clip
+        end
+        2: begin
+          ic0 = image_clip[0]
+          ic1 = image_clip[1]
+        end
+      else: message, 'only 1 or 2 image_clip values allowed'
+    endcase
+
     uvf_options0 = create_uvf_options(delta_uv_lambda = delta_uv_lambda, $
-      max_uv_lambda = mul0, full_image = fi0)
+      max_uv_lambda = mul0, full_image = fi0, image_clip = ic0)
     uvf_options1 = create_uvf_options(delta_uv_lambda = delta_uv_lambda, $
-      max_uv_lambda = mul1, full_image = fi1)
+      max_uv_lambda = mul1, full_image = fi1, image_clip = ic1)
   endelse
 
   if n_elements(ave_removal) lt 2 and n_elements(wt_cutoffs) lt 2 and $

--- a/ps_wrappers/ps_wrapper.pro
+++ b/ps_wrappers/ps_wrapper.pro
@@ -9,7 +9,7 @@ pro ps_wrapper, folder_name_in, obs_name, data_subdirs=data_subdirs, $
     refresh_binning = refresh_binning, refresh_info = refresh_info, $
     refresh_beam = refresh_beam, dft_fchunk = dft_fchunk, require_radec = require_radec, $
     delta_uv_lambda = delta_uv_lambda, max_uv_lambda = max_uv_lambda, $
-    full_image = full_image, $
+    full_image = full_image, image_clip = image_clip, $
     pol_inc = pol_inc, type_inc = type_inc, freq_ch_range = freq_ch_range, $
     freq_flags = freq_flags, freq_flag_name = freq_flag_name, $
     allow_beam_approx = allow_beam_approx, uvf_input = uvf_input, uv_avg = uv_avg, $
@@ -167,6 +167,7 @@ pro ps_wrapper, folder_name_in, obs_name, data_subdirs=data_subdirs, $
       plot_filebase = plot_filebase + '_' + obs_info.obs_names[0]
 
     note = obs_info.fhd_types[0]
+    if ps_foldername ne 'ps' then note = note + '_' + ps_foldername
     if keyword_set(uvf_input) then note = note + '_uvf'
 
     if tag_exist(obs_info, 'beam_files') then beamfiles = obs_info.beam_files
@@ -250,7 +251,7 @@ pro ps_wrapper, folder_name_in, obs_name, data_subdirs=data_subdirs, $
     refresh_binning = refresh_binning, refresh_info = refresh_info)
 
   uvf_options = create_uvf_options(delta_uv_lambda = delta_uv_lambda, $
-    max_uv_lambda = max_uv_lambda, full_image = full_image, $
+    max_uv_lambda = max_uv_lambda, full_image = full_image, image_clip = image_clip, $
     uv_avg = uv_avg, uv_img_clip = uv_img_clip, require_radec = require_radec, $
     dft_fchunk = dft_fchunk, no_dft_progress = no_dft_progress)
 


### PR DESCRIPTION
This adds an `image_clip` option, the old default behavior was to use the image clip (small image). This is now an option which is defaulted to off so that the full image is used with the standard uv pixel size.

There is also a `full_image` option, which this PR does not change, which uses the full image and smaller uv pixels set by the size of the image. Using the standard uv pixel size (the new default) means that the pixels are close to uncorrelated, which is the assumption in the rest of the code and also makes it run much faster.