### PR TITLE
change arrays to doubles

### DIFF
--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1574,27 +1574,27 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
       endif
     endif
 
-    data_sum_cos = complex(fltarr(n_kx, n_ky, n_kz))
-    data_sum_sin = complex(fltarr(n_kx, n_ky, n_kz))
+    data_sum_cos = dcomplex(fltarr(n_kx, n_ky, n_kz))
+    data_sum_sin = dcomplex(fltarr(n_kx, n_ky, n_kz))
     data_sum_cos[*, *, 0] = a1_0
     data_sum_cos[*, *, 1:n_kz-1] = a1_n
     data_sum_sin[*, *, 1:n_kz-1] = b1_n
 
-    sim_noise_sum_cos = complex(fltarr(n_kx, n_ky, n_kz))
-    sim_noise_sum_sin = complex(fltarr(n_kx, n_ky, n_kz))
+    sim_noise_sum_cos = dcomplex(fltarr(n_kx, n_ky, n_kz))
+    sim_noise_sum_sin = dcomplex(fltarr(n_kx, n_ky, n_kz))
     sim_noise_sum_cos[*, *, 0] = a3_0
     sim_noise_sum_cos[*, *, 1:n_kz-1] = a3_n
     sim_noise_sum_sin[*, *, 1:n_kz-1] = b3_n
 
     if nfiles gt 1 then begin
-      data_diff_cos = complex(fltarr(n_kx, n_ky, n_kz))
-      data_diff_sin = complex(fltarr(n_kx, n_ky, n_kz))
+      data_diff_cos = dcomplex(fltarr(n_kx, n_ky, n_kz))
+      data_diff_sin = dcomplex(fltarr(n_kx, n_ky, n_kz))
       data_diff_cos[*, *, 0] = a2_0
       data_diff_cos[*, *, 1:n_kz-1] = a2_n
       data_diff_sin[*, *, 1:n_kz-1] = b2_n
 
-      sim_noise_diff_cos = complex(fltarr(n_kx, n_ky, n_kz))
-      sim_noise_diff_sin = complex(fltarr(n_kx, n_ky, n_kz))
+      sim_noise_diff_cos = dcomplex(fltarr(n_kx, n_ky, n_kz))
+      sim_noise_diff_sin = dcomplex(fltarr(n_kx, n_ky, n_kz))
       sim_noise_diff_cos[*, *, 0] = a4_0
       sim_noise_diff_cos[*, *, 1:n_kz-1] = a4_n
       sim_noise_diff_sin[*, *, 1:n_kz-1] = b4_n
@@ -1657,7 +1657,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
 
     ;; get rotation angle to diagonalize covariance block
     theta = atan(2.*covar_cross, covar_cos - covar_sin)/2.
-
+theta[*,*,*]=0.
     cos_theta = cos(theta)
     sin_theta = sin(theta)
     undefine, theta

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1657,7 +1657,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
 
     ;; get rotation angle to diagonalize covariance block
     theta = atan(2.*covar_cross, covar_cos - covar_sin)/2.
-theta[*,*,*]=0.
+
     cos_theta = cos(theta)
     sin_theta = sin(theta)
     undefine, theta


### PR DESCRIPTION
Change cos and sin arrays to hold doubles.

Here is a difference between master and changing to doubles (no LS rotation done for simplicity). No significant changes, but perhaps a better estimation of the first coarse band at roughly the EoR level.
![ps_stdft__master_minus_doublearr](https://user-images.githubusercontent.com/5588290/60693840-211f1b00-9f1f-11e9-9430-d4a19ae286bd.png)
