### PR TITLE
Add freq_dft option

### DIFF
--- a/dictionary.md
+++ b/dictionary.md
@@ -187,75 +187,25 @@ suppress the printing of progress report statements during the DFT.
 
 ## Power spectrum calculation keywords:
 
-**ave_removal**: This is a flag (valid values are 0/1, default=1) indicating
-that the average along the frequency axis of the cubes should be removed before
-the frequency Fourier Transform and then added back in to the k_parallel=0
-mode. This has been well tested and substantially reduces the bleed of the flat
-spectrum foregrounds into the window.
+**ave_removal**: This is a flag (valid values are 0/1, default=1) indicating that the average along the frequency axis of the cubes should be removed before the frequency Fourier Transform and then added back in to the k_parallel=0 mode. This has been well tested and substantially reduces the bleed of the flat spectrum foregrounds into the window.
 
-**wt_cutoffs**: This is a keyword to support a very subtle power spectrum
-normalization issue identified by Adrian Liu and quantified for MWA with
-simulations. It turns out that when baselines substantially overlap there is a
-suppression of the power of stochastic fields (like the EoR). We measure this
-overlap using the weights cube and we found through simulations that for MWA
-antennas, above a certain weight value the power suppression asymptotes to a
-factor of 0.5. A conservative weight value to use to be sure we are in that
-regime is a weight value of 1, and if we throw away bins below that value we
-lose very little sensitivity with the MWA. The wt_cutoffs keyword is the
-weights value to use for the cutoff value (it is calculated in uvf space, so it
-applies to all kz values for a given kx,ky pixel). It is defaulted to 1.0 and
-is only used during the binnning to 1D or 2D power spectra (for 2D, it is used
-to normalize areas of the ps properly but lower values are not thrown out, for
-1D, pixels with lower values are excluded and the power spectrum is
-normalized by a factor of 2). To turn this normalization correction off, set
-wt_cutoffs=0.
+**wt_cutoffs**: This is a keyword to support a very subtle power spectrum normalization issue identified by Adrian Liu and quantified for MWA with simulations. It turns out that when baselines substantially overlap there is a suppression of the power of stochastic fields (like the EoR). We measure this overlap using the weights cube and we found through simulations that for MWA antennas, above a certain weight value the power suppression asymptotes to a factor of 0.5. A conservative weight value to use to be sure we are in that regime is a weight value of 1, and if we throw away bins below that value we lose very little sensitivity with the MWA. The wt_cutoffs keyword is the weights value to use for the cutoff value (it is calculated in uvf space, so it applies to all kz values for a given kx,ky pixel). It is defaulted to 1.0 and is only used during the binnning to 1D or 2D power spectra (for 2D, it is used to normalize areas of the ps properly but lower values are not thrown out, for 1D, pixels with lower values are excluded and the power spectrum is normalized by a factor of 2). To turn this normalization correction off, set wt_cutoffs=0.
 
-**wt_measures**: See the description for wt_cutoffs to get the full context.
-This keyword defines how the weight value for the power normalization is
-quantified in the uv plane given a uvf cube. Options are 'min' (minimum value
-along frequency axis) and 'ave' (average value along frequency axis), default
-is 'min'. We don't see much change between 'min' and 'ave', but 'min' is more
-conservative.
+**wt_measures**: See the description for wt_cutoffs to get the full context. This keyword defines how the weight value for the power normalization is quantified in the uv plane given a uvf cube. Options are 'min' (minimum value along frequency axis) and 'ave' (average value along frequency axis), default is 'min'. We don't see much change between 'min' and 'ave', but 'min' is more conservative.
 
-**spec_window_type**: Name of spectral window to apply in the frequency
-direction before Fourier Transforming. Default is 'Blackman-Harris'. Full set
-of options is: ['Hann', 'Hamming', 'Blackman', 'Nutall', 'Blackman-Nutall',
-'Blackman-Harris', 'Blackman-Harris^2'].
+**spec_window_type**: Name of spectral window to apply in the frequency direction before Fourier Transforming. Default is 'Blackman-Harris'. Full set of options is: ['Hann', 'Hamming', 'Blackman', 'Nutall', 'Blackman-Nutall', 'Blackman-Harris', 'Blackman-Harris^2'].
 
-**no_spec_window**: This is a flag (valid values are 0/1, default=0) indicating
-that no spectral window should be applied (see spec_window_type keyword).
+**no_spec_window**: This is a flag (valid values are 0/1, default=0) indicating that no spectral window should be applied (see spec_window_type keyword).
 
-**dft_z_use**: This controls what z values to use in the frequency DFT. This
-only applies if the frequency channels are not evenly spaced (in which case we
-do a DFT rather than an FFT). The two options are 'true' or 'regular':
-'true' uses the actual z values,  'regular'  uses regularly spaced z values
-which matches what would happen with an FFT over regularly spaced frequency
-channels (which are not regularly spaced in z). The default is 'true'.
+**allow_beam_approx**: This is a flag (valid values are 0/1, default=0) indicating that a less good beam integral approximation should be used if the beam_integral is not present or is zero in the obs structure. If this keyword is not set and the beam_integral is not present or is zero, eppsilon will fail fairly quickly. If this keyword is set and the beam_integral is not present or is zero, eppsilon will print a warning but continue using a less good approximation.
 
-**allow_beam_approx**: This is a flag (valid values are 0/1, default=0)
-indicating that a less good beam integral approximation should be used if the
-beam_integral is not present or is zero in the obs structure. If this keyword
-is not set and the beam_integral is not present or is zero, eppsilon will fail
-fairly quickly. If this keyword is set and the beam_integral is not present or
-is zero, eppsilon will print a warning but continue using a less good
-approximation.
+**dft_z_use**: This controls what z values to use in the frequency DFT. This only applies if the frequency channels are not evenly spaced (in which case we do a DFT rather than an FFT). The two options are 'true' or 'regular', the default is 'true' which uses the actual z values. The 'regular' option uses regularly spaced z values which matches what would happen with an FFT over regularly spaced frequency channels (which are not regularly spaced in z).
 
-**std_power**: A rarely used testing/exploration flag (valid values are 0/1,
-default=0) indicating that the power should be calculated using the sine and
-cosine terms of the FFT along the frequency axis, rather than the
-Lomb-Scargle components.
+**std_power**: A rarely used testing/exploration flag (valid values are 0/1, default=0) indicating that the power should be calculated using the sine and cosine terms of the FFT along the frequency axis, rather than the Lomb-Scargle components.
 
-**no_wtd_avg**: A rarely used testing/exploration flag (valid values are 0/1,
-default=0) indicating that the power should be calculated as the sum of the
-square of the two Fourier Transform components (either Lomb-Scargle components
-or sine/cosine components if the std_power flag is set), rather than as a
-variance weighted sum of the square of the components.
+**no_wtd_avg**: A rarely used testing/exploration flag (valid values are 0/1, default=0) indicating that the power should be calculated as the sum of the square of the two Fourier Transform components (either Lomb-Scargle components or sine/cosine components if the std_power flag is set), rather than as a variance weighted sum of the square of the components.
 
-**inverse_covar_weight**: *This is very much under development and is not yet
-trustworthy.* A rarely used testing/exploration flag (valid values are 0/1,
-default=0) that constructs a frequency covariance matrix assuming flat spectrum
-foregrounds, transforms it to k_parallel and uses it to weight the power
-spectra.
+**inverse_covar_weight**: *This is very much under development and is not yet trustworthy.* A rarely used testing/exploration flag (valid values are 0/1, default=0) that constructs a frequency covariance matrix assuming flat spectrum foregrounds, transforms it to k_parallel and uses it to weight the power spectra.
 
 
 ## Power spectrum binning keywords:

--- a/dictionary.md
+++ b/dictionary.md
@@ -199,7 +199,9 @@ suppress the printing of progress report statements during the DFT.
 
 **allow_beam_approx**: This is a flag (valid values are 0/1, default=0) indicating that a less good beam integral approximation should be used if the beam_integral is not present or is zero in the obs structure. If this keyword is not set and the beam_integral is not present or is zero, eppsilon will fail fairly quickly. If this keyword is set and the beam_integral is not present or is zero, eppsilon will print a warning but continue using a less good approximation.
 
-**dft_z_use**: This controls what z values to use in the frequency DFT. This only applies if the frequency channels are not evenly spaced (in which case we do a DFT rather than an FFT). The two options are 'true' or 'regular', the default is 'true' which uses the actual z values. The 'regular' option uses regularly spaced z values which matches what would happen with an FFT over regularly spaced frequency channels (which are not regularly spaced in z).
+**freq_dft**: This is a flag (valid values are 0/1, default=1) that specifies a DFT rather than an FFT for the frequency transform. Using a DFT allows for using the true z values because they are generally unevenly spaced (even if the frequencies are evenly spaced). If the frequencies are unevenly spaced a DFT is forced no matter what.
+
+**dft_z_use**: This controls what z values to use in the frequency DFT. This only applies if the frequency channels are not evenly spaced or if freq_dft is set. The two options are 'true' or 'regular', the default is 'true' which uses the actual z values. The 'regular' option uses regularly spaced z values which matches what would happen with an FFT over regularly spaced frequency channels (which are not regularly spaced in z).
 
 **std_power**: A rarely used testing/exploration flag (valid values are 0/1, default=0) indicating that the power should be calculated using the sine and cosine terms of the FFT along the frequency axis, rather than the Lomb-Scargle components.
 

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -36,14 +36,14 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
     redshifts = redshifts, comov_dist_los = comov_dist_los, $
     z_mpc_delta = z_mpc_delta)
 
-  kperp_lambda_conv = z_mpc_mean / (2.*!pi)
+  kperp_lambda_conv = z_mpc_mean / (2.*!dpi)
   delay_delta = 1e9/(n_freq*f_delta*1e6) ;; equivilent delay bin size for kparallel
   delay_max = delay_delta * n_freq/2.    ;; factor of 2 b/c of neg/positive
   delay_params = [delay_delta, delay_max]
 
   z_mpc_length = max(comov_dist_los) - min(comov_dist_los) + z_mpc_delta
-  kz_mpc_range =  (2.*!pi) / (z_mpc_delta)
-  kz_mpc_delta = (2.*!pi) / z_mpc_length
+  kz_mpc_range =  (2.*!dpi) / (z_mpc_delta)
+  kz_mpc_delta = (2.*!dpi) / z_mpc_length
 
   ;; need to figure out where the zero bin is (for later computations)
   ;; The location of the zero bin also dictates what the most negative kz bin is (min_kz)

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1403,7 +1403,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   endif else begin
     ;; Not evenly spaced or DFT requested.
     ;; use the kz_mpc_orig_trim to avoid the possible extra positive mode.
-    print, "Uneven frequency structure found"
+    print, "Uneven frequency structure found or DFT requested (default)"
     print, "Performing Discrete Fourier Transform"
 
     ;; There are 2 options for the DFT. One will get the (very nearly) the same answer

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1364,7 +1364,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   endelse
 
   ;; now take frequency FT
-  if not ps_options.force_dft then begin
+  if not ps_options.freq_dft then begin
     ;; evenly spaced and dft not requested, just use fft
     print, "Using FFT for evenly spaced frequencies"
     data_sum_ft = fft(data_sum, dimension=3) * n_freq * z_mpc_delta
@@ -1417,7 +1417,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
     ;; in some simple testing, this had a difference ratio vs the FFT (abs(diff)/abs(fft)) of ~10^1
     z_exp_ztrue =  exp(-1.*complex(0,1)*matrix_multiply(reverse(comov_dist_los-min(comov_dist_los)), kz_mpc_orig_trim, /btranspose))
 
-    case ps_options.dft_z_use of:
+    case ps_options.dft_z_use of
       'true': z_exp = z_exp_ztrue
       'regular': z_exp = z_exp_zreg
     endcase
@@ -1543,7 +1543,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   covar_sin = fltarr(n_kx, n_ky, n_kz)
   covar_cross = fltarr(n_kx, n_ky, n_kz)
 
-  if not ps_options.force_dft then begin
+  if not ps_options.freq_dft then begin
     ;; comov_dist_los goes from large to small z
     z_relative = dindgen(n_freq)*z_mpc_delta
     freq_kz_arr = rebin(reform(kz_mpc, 1, n_kz), n_freq, n_kz) * $
@@ -1556,7 +1556,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
     freq_kz_arr_true = rebin(reform(kz_mpc, 1, n_kz), n_freq, n_kz) * $
       rebin(reverse(comov_dist_los-min(comov_dist_los)), n_freq, n_kz)
 
-    case ps_options.dft_z_use of:
+    case ps_options.dft_z_use of
       'true': freq_kz_arr = freq_kz_arr_true
       'regular': freq_kz_arr = freq_kz_arr_reg
     endcase

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1550,11 +1550,11 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
       rebin(z_relative, n_freq, n_kz)
   endif else begin
     ;; unevenly spaced frequencies. Need to match what is done above
-    freq_kz_arr_reg = rebin(reform(kz_mpc_orig_trim, 1, n_kz), n_freq, n_kz) * $
+    freq_kz_arr_reg = rebin(reform(kz_mpc, 1, n_kz), n_freq, n_kz) * $
       rebin(z_reg, n_freq, n_kz)
 
-    freq_kz_arr_true = rebin(reform(kz_mpc_orig_trim, 1, n_kz), n_freq, n_kz) * $
-      rebin(reverse(comov_dist_los-min(comov_dist_los), n_freq, n_kz)
+    freq_kz_arr_true = rebin(reform(kz_mpc, 1, n_kz), n_freq, n_kz) * $
+      rebin(reverse(comov_dist_los-min(comov_dist_los)), n_freq, n_kz)
 
     case ps_options.dft_z_use of:
       'true': freq_kz_arr = freq_kz_arr_true

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -33,7 +33,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   n_freq = n_elements(frequencies)
 
   z_mpc_mean = z_mpc(frequencies, hubble_param = hubble_param, f_delta = f_delta, $
-    even_freq = even_freq, redshifts = redshifts, comov_dist_los = comov_dist_los, $
+    redshifts = redshifts, comov_dist_los = comov_dist_los, $
     z_mpc_delta = z_mpc_delta)
 
   kperp_lambda_conv = z_mpc_mean / (2.*!pi)
@@ -1364,8 +1364,8 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   endelse
 
   ;; now take frequency FT
-  if even_freq then begin
-    ;; evenly spaced, just use fft
+  if not ps_options.force_dft then begin
+    ;; evenly spaced and dft not requested, just use fft
     print, "Using FFT for evenly spaced frequencies"
     data_sum_ft = fft(data_sum, dimension=3) * n_freq * z_mpc_delta
     sim_noise_sum_ft = fft(sim_noise_sum, dimension=3) * n_freq * z_mpc_delta
@@ -1401,7 +1401,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
       undefine, sim_noise_diff
     endif
   endif else begin
-    ;; Not evenly spaced. Do a dft
+    ;; Not evenly spaced or DFT requested.
     ;; use the kz_mpc_orig_trim to avoid the possible extra positive mode.
     print, "Uneven frequency structure found"
     print, "Performing Discrete Fourier Transform"
@@ -1543,7 +1543,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   covar_sin = fltarr(n_kx, n_ky, n_kz)
   covar_cross = fltarr(n_kx, n_ky, n_kz)
 
-  if even_freq then begin
+  if not ps_options.force_dft then begin
     ;; comov_dist_los goes from large to small z
     z_relative = dindgen(n_freq)*z_mpc_delta
     freq_kz_arr = rebin(reform(kz_mpc, 1, n_kz), n_freq, n_kz) * $

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1550,11 +1550,11 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
       rebin(z_relative, n_freq, n_kz)
   endif else begin
     ;; unevenly spaced frequencies. Need to match what is done above
-    freq_kz_arr_reg = rebin(reform(kz_mpc, 1, n_kz), n_freq, n_kz) * $
+    freq_kz_arr_reg = rebin(reform(kz_mpc_orig_trim, 1, n_kz), n_freq, n_kz) * $
       rebin(z_reg, n_freq, n_kz)
 
-    freq_kz_arr_true = rebin(reform(kz_mpc, 1, n_kz), n_freq, n_kz) * $
-      rebin(reverse(comov_dist_los-min(comov_dist_los)), n_freq, n_kz)
+    freq_kz_arr_true = rebin(reform(kz_mpc_orig_trim, 1, n_kz), n_freq, n_kz) * $
+      rebin(reverse(comov_dist_los-min(comov_dist_los), n_freq, n_kz)
 
     case ps_options.dft_z_use of:
       'true': freq_kz_arr = freq_kz_arr_true

--- a/ps_plotting/ps_ratio_plots.pro
+++ b/ps_plotting/ps_ratio_plots.pro
@@ -125,8 +125,8 @@ pro ps_ratio_plots, folder_names, obs_info, cube_types, pols, ps_foldernames=ps_
         hubble_param2 = getvar_savefile(compare_files.input_savefile1[slice_i, 2*i+1], 'hubble_param')
         hubble_param3 = getvar_savefile(compare_files.input_savefile2[slice_i, 2*i], 'hubble_param')
         hubble_param4 = getvar_savefile(compare_files.input_savefile2[slice_i, 2*i+1], 'hubble_param')
-        if abs(hubble_param - hubble_param2) ne 0  or  abs(hubble_param - hubble_param4) ne 0 or $
-          abs(hubble_param - hubble_param4) ne 0 then message, 'hubble_param do not match in savefiles'
+        if abs(hubble_param - hubble_param2) gt 1.0e-5  or  abs(hubble_param - hubble_param3) gt 1.0e-5 or $
+          abs(hubble_param - hubble_param4) gt 1.0e-5 then message, 'hubble_param do not match in savefiles'
 
         power1a = getvar_savefile(compare_files.input_savefile1[slice_i, 2*i], 'power')
         power2a = getvar_savefile(compare_files.input_savefile1[slice_i, 2*i+1], 'power')

--- a/ps_setup/create_file_tags.pro
+++ b/ps_setup/create_file_tags.pro
@@ -63,6 +63,11 @@ function create_file_tags, freq_ch_range = freq_ch_range, freq_flags = freq_flag
   uvf_tag = uv_tag + fch_tag
 
   if ps_options.std_power then kcube_tag = '_stdp' else kcube_tag = ''
+  if ps_options.freq_dft then begin
+    kcube_tag = kcube_tag + '_dft'
+    ;; add a tag for using the regularly spaced approximate z rather than true z
+    if ps_options.dft_z_use eq 'regular' then kcube_tag = kcube_tag + 'reg'
+  endif
   if ps_options.inverse_covar_weight then kcube_tag = kcube_tag + '_invcovar'
   if ps_options.ave_removal then kcube_tag = kcube_tag + '_averemove'
   kcube_tag = kcube_tag + sw_tag

--- a/ps_setup/create_ps_options.pro
+++ b/ps_setup/create_ps_options.pro
@@ -22,7 +22,7 @@ function create_ps_options, ps_options = ps_options, $
     if n_elements(no_spec_window) eq 0 then no_spec_window = 0
 
     ;; Default to using a frequency DFT.
-    if n_elements(freq_dft) then freq_dft = 1
+    if n_elements(freq_dft) eq 0 then freq_dft = 1
 
     ;; default to using the true z's if using a DFT
     if n_elements(dft_z_use) eq 0 then dft_z_use = 'true'

--- a/ps_setup/create_ps_options.pro
+++ b/ps_setup/create_ps_options.pro
@@ -21,10 +21,6 @@ function create_ps_options, ps_options = ps_options, $
     if n_elements(no_spec_window) eq 0 then no_spec_window = 0
 
     ;; default to using the true z's if frequencies aren't evenly spaced
-    ;; NOTE not sure this is the best choice but it is what is already in the code
-    ;; NOTE this isn't currently used to update filenames. It probably should
-    ;; but then we'd need to move the code that checks for even freq. sampling
-    ;; upstream
     if n_elements(dft_z_use) eq 0 then dft_z_use = 'true'
 
     ;; default to Lomb-Scargle power calc

--- a/ps_setup/create_ps_options.pro
+++ b/ps_setup/create_ps_options.pro
@@ -2,7 +2,8 @@ function create_ps_options, ps_options = ps_options, $
     ave_removal = ave_removal, wt_cutoffs = wt_cutoffs, $
     wt_measures = wt_measures, spec_window_type = spec_window_type, $
     no_spec_window = no_spec_window, allow_beam_approx = allow_beam_approx, $
-    dft_z_use = dft_z_use, std_power = std_power, no_wtd_avg = no_wtd_avg, $
+    freq_dft = freq_dft, dft_z_use = dft_z_use, $
+    std_power = std_power, no_wtd_avg = no_wtd_avg, $
     inverse_covar_weight = inverse_covar_weight, return_new = return_new
 
   ;; if inverse covariance weighted don't use spectral window
@@ -20,7 +21,10 @@ function create_ps_options, ps_options = ps_options, $
     ;; default to not turning off spectral windowing
     if n_elements(no_spec_window) eq 0 then no_spec_window = 0
 
-    ;; default to using the true z's if frequencies aren't evenly spaced
+    ;; Default to using a frequency DFT.
+    if n_elements(freq_dft) then freq_dft = 1
+
+    ;; default to using the true z's if using a DFT
     if n_elements(dft_z_use) eq 0 then dft_z_use = 'true'
 
     ;; default to Lomb-Scargle power calc
@@ -81,6 +85,11 @@ function create_ps_options, ps_options = ps_options, $
   if n_elements(spec_window_type) gt 0 then begin
     update_tags.add, 'spec_window_type'
     update_values.add, spec_window_type
+  endif
+
+  if n_elements(freq_dft) gt 0 then begin
+    update_tags.add, 'freq_dft'
+    update_values.add, freq_dft
   endif
 
   if n_elements(dft_z_use) gt 0 then begin

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -1017,6 +1017,16 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       frequencies = freq / 1e6 ;; in MHz
     endelse
 
+    ;; check frequency spacing to determine if a frequency DFT is required.
+    if not ps_options.freq_dft then begin
+      freq_diff = frequencies - shift(frequencies, 1)
+      freq_diff = freq_diff[1:*]
+      if max(abs(freq_diff-freq_diff[0])) gt 1e-12 then begin
+        ps_options = create_ps_options(ps_options = ps_options, $
+          freq_dft = 1)
+      endif
+    endif
+
     metadata_struct = {datafile: datafile, weightfile: weightfile, $
       variancefile:variancefile, cube_varname:cube_varname, $
       weight_varname:weight_varname, variance_varname:variance_varname, $

--- a/ps_utils/cosmology_measures.pro
+++ b/ps_utils/cosmology_measures.pro
@@ -1,7 +1,7 @@
 
 function Ez_inv, redshift
   Common cosmological_params, h, Om, Ol, Ok
-  return, 1d/sqrt(Om*(1 + redshift)^3 + Ok*(1 + redshift)^2 + Ol)
+  return, 1d/sqrt(Om*(1d + redshift)^3d + Ok*(1d + redshift)^2d + Ol)
 end
 
 pro cosmology_measures, redshift, hubble_param = hubble_param, omega_matter = omega_matter, omega_lambda = omega_lambda, $
@@ -9,10 +9,10 @@ pro cosmology_measures, redshift, hubble_param = hubble_param, omega_matter = om
                         wedge_factor = wedge_factor
 
   ;; using WMAP7 values as defaults
-  if not keyword_set(hubble_param) then hubble_param = 0.71
-  if not keyword_set(omega_matter) then omega_matter = 0.27
-  if not keyword_set(omega_lambda) then omega_lambda = 0.73
-  if not keyword_set(omega_curv) then omega_curv = 0.
+  if not keyword_set(hubble_param) then hubble_param = 0.71d
+  if not keyword_set(omega_matter) then omega_matter = 0.27d
+  if not keyword_set(omega_lambda) then omega_lambda = 0.73d
+  if not keyword_set(omega_curv) then omega_curv = 0.d
 
   Common cosmological_params
   h = hubble_param
@@ -21,7 +21,7 @@ pro cosmology_measures, redshift, hubble_param = hubble_param, omega_matter = om
   Ok = omega_curv
 
   hubble_distance = 3000d / hubble_param
-  Ez = sqrt(Om*(1 + redshift)^3 + Ok*(1 + redshift)^2 + Ol)
+  Ez = sqrt(Om*(1d + redshift)^3d + Ok*(1d + redshift)^2d + Ol)
  
   intreg = qromb('Ez_inv', 0, redshift, /double)
   comoving_dist_los = hubble_distance * intreg

--- a/ps_utils/z_mpc.pro
+++ b/ps_utils/z_mpc.pro
@@ -51,7 +51,7 @@ function z_mpc, frequencies, hubble_param = hubble_param, f_delta = f_delta, eve
   endif else begin
     even_freq = 1
 
-    f_delta = freq_diff[0]
+    f_delta = double(mean(freq_diff)) ;take the mean to reduce precision errors
     z_mpc_delta = double(mean(comov_los_diff))
     z_mpc_mean = double(mean(comov_dist_los))
     n_kz = n_freq

--- a/ps_wrappers/ps_diff_wrapper.pro
+++ b/ps_wrappers/ps_diff_wrapper.pro
@@ -1,9 +1,10 @@
-pro ps_diff_wrapper, folder_names_in, obs_names_in, ps_foldernames = ps_foldernames, $
-    version_test = version_test, $
+pro ps_diff_wrapper, folder_names_in, obs_names_in, $
+    ps_foldernames = ps_foldernames, version_test = version_test, $
     cube_types = cube_types, pols = pols,  refresh_diff = refresh_diff, $
     spec_window_types = spec_window_types, delta_uv_lambda = delta_uv_lambda, $
-    max_uv_lambda = max_uv_lambda, full_image = full_image, image_clip = image_clip, $
-    ave_removal = ave_removal, std_power = std_power, $
+    max_uv_lambda = max_uv_lambda, full_image = full_image, $
+    image_clip = image_clip, ave_removal = ave_removal, $
+    freq_dft = freq_dft, dft_z_use = dft_z_use, std_power = std_power, $
     all_type_pol = all_type_pol, freq_ch_range = freq_ch_range, $
     plot_slices = plot_slices, slice_type = slice_type, $
     png = png, eps = eps, pdf = pdf, data_range = data_range, data_min_abs = data_min_abs, $
@@ -115,10 +116,14 @@ pro ps_diff_wrapper, folder_names_in, obs_names_in, ps_foldernames = ps_folderna
 
   if n_elements(ave_removal) lt 2 and n_elements(wt_cutoffs) lt 2 and $
     n_elements(wt_measures) lt 2 and n_elements(spec_window_types) lt 2 and $
+    n_elements(freq_dft) lt 2 and n_elements(dft_z_use) lt 2 and $
     n_elements(std_power) lt 2 then begin
 
-    ps_options = create_ps_options(ave_removal = ave_removal, wt_cutoffs = wt_cutoffs, $
-      wt_measures = wt_measures, spec_window_type = spec_window_types, std_power = std_power)
+    ps_options = create_ps_options(ave_removal = ave_removal, $
+    wt_cutoffs = wt_cutoffs, wt_measures = wt_measures, $
+    spec_window_type = spec_window_types, $
+    freq_dft = freq_dft, dft_z_use = dft_z_use, $
+    std_power = std_power)
 
   endif else begin
     case n_elements(ave_removal) of
@@ -173,6 +178,32 @@ pro ps_diff_wrapper, folder_names_in, obs_names_in, ps_foldernames = ps_folderna
       else: message, 'only 1 or 2 spec_window_types allowed'
     endcase
 
+    case n_elements(freq_dft) of
+      0:
+      1: begin
+        dft0 = freq_dft
+        dft1 = freq_dft
+      end
+      2: begin
+        dft0 = freq_dft[0]
+        dft1 = freq_dft[1]
+      end
+      else: message, 'only 1 or 2 freq_dft values allowed'
+    endcase
+
+    case n_elements(dft_z_use) of
+      0:
+      1: begin
+        dftz0 = dft_z_use
+        dftz1 = dft_z_use
+      end
+      2: begin
+        dftz0 = dft_z_use[0]
+        dftz1 = dft_z_use[1]
+      end
+      else: message, 'only 1 or 2 dft_z_use values allowed'
+    endcase
+
     case n_elements(std_power) of
       0:
       1: begin
@@ -187,10 +218,12 @@ pro ps_diff_wrapper, folder_names_in, obs_names_in, ps_foldernames = ps_folderna
     endcase
 
     ps_options0 = create_ps_options(ave_removal = ar0, wt_cutoffs = wtc0, $
-      wt_measures = wtm0, spec_window_type = spw0, std_power = sp0)
+      wt_measures = wtm0, spec_window_type = spw0, freq_dft = dft0, $
+      dft_z_use = dftz0, std_power = sp0)
 
     ps_options1 = create_ps_options(ave_removal = ar1, wt_cutoffs = wtc1, $
-      wt_measures = wtm1, spec_window_type = spw1, std_power = sp1)
+      wt_measures = wtm1, spec_window_type = spw1, freq_dft = dft1, $
+      dft_z_use = dftz1, std_power = sp1)
 
     ps_options = [ps_options0, ps_options1]
   endelse

--- a/ps_wrappers/ps_wrapper.pro
+++ b/ps_wrappers/ps_wrapper.pro
@@ -13,7 +13,7 @@ pro ps_wrapper, folder_name_in, obs_name, data_subdirs=data_subdirs, $
     pol_inc = pol_inc, type_inc = type_inc, freq_ch_range = freq_ch_range, $
     freq_flags = freq_flags, freq_flag_name = freq_flag_name, $
     allow_beam_approx = allow_beam_approx, uvf_input = uvf_input, uv_avg = uv_avg, $
-    uv_img_clip = uv_img_clip, freq_dft = freq_dft, dft_z_use = dft_z_use,
+    uv_img_clip = uv_img_clip, freq_dft = freq_dft, dft_z_use = dft_z_use, $
     std_power = std_power, $
     inverse_covar_weight = inverse_covar_weight, ave_removal = ave_removal, $
     no_wtd_avg = no_wtd_avg, norm_rts_with_fhd = norm_rts_with_fhd, $

--- a/ps_wrappers/ps_wrapper.pro
+++ b/ps_wrappers/ps_wrapper.pro
@@ -13,7 +13,8 @@ pro ps_wrapper, folder_name_in, obs_name, data_subdirs=data_subdirs, $
     pol_inc = pol_inc, type_inc = type_inc, freq_ch_range = freq_ch_range, $
     freq_flags = freq_flags, freq_flag_name = freq_flag_name, $
     allow_beam_approx = allow_beam_approx, uvf_input = uvf_input, uv_avg = uv_avg, $
-    uv_img_clip = uv_img_clip, dft_z_use = dft_z_use, std_power = std_power, $
+    uv_img_clip = uv_img_clip, freq_dft = freq_dft, dft_z_use = dft_z_use,
+    std_power = std_power, $
     inverse_covar_weight = inverse_covar_weight, ave_removal = ave_removal, $
     no_wtd_avg = no_wtd_avg, norm_rts_with_fhd = norm_rts_with_fhd, $
     use_weight_cutoff_sim = use_weight_cutoff_sim, $
@@ -258,7 +259,8 @@ pro ps_wrapper, folder_name_in, obs_name, data_subdirs=data_subdirs, $
   ps_options = create_ps_options(ave_removal = ave_removal, wt_cutoffs = wt_cutoffs, $
     wt_measures = wt_measures, spec_window_type = spec_window_type, $
     no_spec_window = no_spec_window, allow_beam_approx = allow_beam_approx, $
-    dft_z_use = dft_z_use, std_power = std_power, no_wtd_avg = no_wtd_avg, $
+    freq_dft = freq_dft, dft_z_use = dft_z_use, $
+    std_power = std_power, no_wtd_avg = no_wtd_avg, $
     inverse_covar_weight = inverse_covar_weight)
 
   binning_2d_options = create_binning_2d_options(no_kzero = no_kzero, $


### PR DESCRIPTION
Add an option to do a frequency DFT even in the case of even frequency spacing to allow for using the true z values.

Cannot be merged until #119 is.

fixes #123 