### PR TITLE
Change to using a symmetric window rather than an asymmetric one for even numbers of frequencies

### DIFF
--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1239,6 +1239,8 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
 
   ;; apply spectral windowing function if desired
   if tag_exist(ps_options, 'spec_window_type') then begin
+    ;; set the periodic keyword in the call below to get an asymmetric
+    ;; rather than a symmetric window.
     window = spectral_window(n_freq, type = ps_options.spec_window_type)
 
     ;; this is the equivilent bandwidth reduction (approx. 2 for blackman-harris)

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1239,7 +1239,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
 
   ;; apply spectral windowing function if desired
   if tag_exist(ps_options, 'spec_window_type') then begin
-    window = spectral_window(n_freq, type = ps_options.spec_window_type, /periodic)
+    window = spectral_window(n_freq, type = ps_options.spec_window_type)
 
     ;; this is the equivilent bandwidth reduction (approx. 2 for blackman-harris)
     norm_factor = sqrt(n_freq/total(window^2.))


### PR DESCRIPTION
Needs to be tested. Cath reports that she finds a symmetric window performs better, but in my very simple tests it looks like it might be worse in eppsilon.

fixes #124 