### PR TITLE
Observation volume calculation

### DIFF
--- a/ps_core/ps_image_to_uvf.pro
+++ b/ps_core/ps_image_to_uvf.pro
@@ -59,7 +59,6 @@ pro ps_image_to_uvf, file_struct, n_vis_freq, kx_rad_vals, ky_rad_vals, $
         full_uvf_file = strjoin(strsplit(full_uvf_file, '_ch[0-9]+-[0-9]+', /regex, /extract))
       endif
       if n_elements(freq_flags) ne 0 then begin
-        full_uvf_file = strjoin(strsplit(full_uvf_file, '_flag[a-z0-9]+', /regex, /extract))
         full_uvf_file = strjoin(strsplit(full_uvf_file, '_flag+', /regex, /extract))
       endif
       test_full_uvf = file_valid(full_uvf_file)
@@ -100,8 +99,6 @@ pro ps_image_to_uvf, file_struct, n_vis_freq, kx_rad_vals, ky_rad_vals, $
           /regex, /extract))
       endif
       if n_elements(freq_flags) ne 0 then begin
-        full_uvf_wt_file = strjoin(strsplit(full_uvf_wt_file, '_flag[a-z0-9]+', $
-          /regex, /extract))
         full_uvf_wt_file = strjoin(strsplit(full_uvf_wt_file, '_flag+', $
           /regex, /extract))
       endif

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -495,11 +495,21 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
 
       if tag_exist(file_struct, 'beam_int') then begin
         if nfiles eq 2 then begin
-          ave_beam_int = total(file_struct.beam_int * file_struct.n_vis_freq, 2) $
-            / total(file_struct.n_vis_freq, 2)
+          if n_elements(freq_ch_range) ne 0 then begin
+            ave_beam_int = total(file_struct.beam_int[*,freq_ch_range] * file_struct.n_vis_freq[*,freq_ch_range], 2) $
+              / total(file_struct.n_vis_freq[*,freq_ch_range], 2)
+          endif else begin
+            ave_beam_int = total(file_struct.beam_int * file_struct.n_vis_freq, 2) $
+              / total(file_struct.n_vis_freq, 2)
+          endelse
         endif else begin
-          ave_beam_int = total(file_struct.beam_int * file_struct.n_vis_freq) $
-            / total(file_struct.n_vis_freq)
+          if n_elements(freq_ch_range) ne 0 then begin
+            ave_beam_int = total(file_struct.beam_int[freq_ch_range] * file_struct.n_vis_freq[freq_ch_range]) $
+              / total(file_struct.n_vis_freq[freq_ch_range])
+          endif else begin
+            ave_beam_int = total(file_struct.beam_int * file_struct.n_vis_freq) $
+              / total(file_struct.n_vis_freq)
+          endelse
         endelse
 
         ;; fix known units bug in some early runs
@@ -669,11 +679,21 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
 
       if tag_exist(file_struct, 'beam_int') then begin
         if nfiles eq 2 then begin
-          ave_beam_int = total(file_struct.beam_int * file_struct.n_vis_freq, 2) / $
-            total(file_struct.n_vis_freq, 2)
+          if N_elements(freq_ch_range) ne 0 then begin
+            ave_beam_int = total(file_struct.beam_int[*, freq_ch_range] * file_struct.n_vis_freq[*, freq_ch_range], 2) / $
+              total(file_struct.n_vis_freq[*, freq_ch_range], 2)
+          endif else begin
+            ave_beam_int = total(file_struct.beam_int * file_struct.n_vis_freq, 2) / $
+              total(file_struct.n_vis_freq, 2)
+          endelse
         endif else begin
-          ave_beam_int = total(file_struct.beam_int * file_struct.n_vis_freq) / $
-            total(file_struct.n_vis_freq)
+          if N_elements(freq_ch_range) ne 0 then begin
+            ave_beam_int = total(file_struct.beam_int[freq_ch_range] * file_struct.n_vis_freq[freq_ch_range]) / $
+              total(file_struct.n_vis_freq[freq_ch_range])
+          endif else begin
+            ave_beam_int = total(file_struct.beam_int * file_struct.n_vis_freq) / $
+              total(file_struct.n_vis_freq)
+          endelse
         endelse
 
         ;; fix known units bug in some early runs

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -406,7 +406,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
       endif
     endif
     if n_elements(freq_flags) ne 0 then begin
-      flag_arr = rebin(reform(freq_mask, 1, 1, n_elements(file_struct.frequencies)), $
+      flag_arr = rebin(reform(freq_mask, 1, 1, n_freq), $
         size(weights_cube1,/dimension), /sample)
       weights_cube1 = weights_cube1 * flag_arr
       if nfiles eq 2 then weights_cube2 = weights_cube2 * flag_arr
@@ -620,7 +620,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
         if nfiles eq 2 then variance_cube2 = variance_cube2[*, *, min(freq_ch_range):max(freq_ch_range)]
       endif
       if n_elements(freq_flags) ne 0 then begin
-        flag_arr = rebin(reform(freq_mask, 1, 1, n_elements(file_struct.frequencies)), $
+        flag_arr = rebin(reform(freq_mask, 1, 1, n_freq), $
           size(variance_cube1,/dimension), /sample)
         variance_cube1 = variance_cube1 * flag_arr
         if nfiles eq 2 then variance_cube2 = variance_cube2 * flag_arr
@@ -901,7 +901,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
       if nfiles eq 2 then data_cube2 = data_cube2[*, *, min(freq_ch_range):max(freq_ch_range)]
     endif
     if n_elements(freq_flags) ne 0 then begin
-      flag_arr = rebin(reform(freq_mask, 1, 1, n_elements(file_struct.frequencies)), size(data_cube1,/dimension), /sample)
+      flag_arr = rebin(reform(freq_mask, 1, 1, n_freq), size(data_cube1,/dimension), /sample)
       data_cube1 = data_cube1 * flag_arr
       if nfiles eq 2 then data_cube2 = data_cube2 * flag_arr
     endif

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -512,13 +512,6 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
           endelse
         endelse
 
-        ;; fix known units bug in some early runs
-        if max(ave_beam_int) lt 0.01 then begin
-          ave_beam_int = ave_beam_int / (file_struct.kpix)^4.
-        endif else if max(ave_beam_int) lt 0.03 then begin
-          ave_beam_int = ave_beam_int / (file_struct.kpix)^2.
-        endif
-
         ;; convert rad -> Mpc^2, multiply by depth in Mpc
         window_int_beam_obs = ave_beam_int * z_mpc_mean^2. * (z_mpc_delta * n_freq)
       endif
@@ -694,15 +687,6 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
             ave_beam_int = total(file_struct.beam_int * file_struct.n_vis_freq) / $
               total(file_struct.n_vis_freq)
           endelse
-        endelse
-
-        ;; fix known units bug in some early runs
-        if max(ave_beam_int) lt 0.01 then begin
-          ave_beam_int = ave_beam_int / (file_struct.kpix)^4.
-        endif else begin
-          if max(ave_beam_int) lt 0.03 then begin
-            ave_beam_int = ave_beam_int / (file_struct.kpix)^2.
-          endif
         endelse
 
         ;; convert rad -> Mpc^2, multiply by depth in Mpc

--- a/ps_core/single_cube_dft.pro
+++ b/ps_core/single_cube_dft.pro
@@ -157,7 +157,12 @@ pro single_cube_dft, folder_name_in, obs_name, data_subdirs=data_subdirs, $
   test_uvf = file_test(uvf_savefile) *  (1 - file_test(uvf_savefile, /zero_length))
   if test_uvf eq 1 and n_elements(freq_flags) ne 0 then begin
     old_freq_mask = getvar_savefile(file_struct.uvf_savefile[i], 'freq_mask')
-    if total(abs(old_freq_mask - freq_mask)) ne 0 then test_uvf = 0
+    if n_elements(freq_ch_range) ne 0 then begin
+      if total(abs(old_freq_mask[min(freq_ch_range):max(freq_ch_range)] - freq_mask)) ne 0 $
+        then test_uvf = 0
+    endif else begin
+      if total(abs(old_freq_mask - freq_mask)) ne 0 then test_uvf = 0
+    endelse
   endif
 
   if test_uvf eq 0 or keyword_set(refresh_dft) then begin
@@ -220,7 +225,7 @@ pro single_cube_dft, folder_name_in, obs_name, data_subdirs=data_subdirs, $
         arr = arr[*, min(freq_ch_range):max(freq_ch_range)]
       endif
       if n_elements(freq_flags) ne 0 then begin
-        arr = arr * rebin(reform(freq_mask, 1, n_elements(file_struct.frequencies)), $
+        arr = arr * rebin(reform(freq_mask, 1, n_freq), $
           size(arr, /dimension), /sample)
       endif
 
@@ -256,7 +261,7 @@ pro single_cube_dft, folder_name_in, obs_name, data_subdirs=data_subdirs, $
           arr = arr[*, min(freq_ch_range):max(freq_ch_range)]
         endif
         if n_elements(freq_flags) ne 0 then begin
-          arr = arr * rebin(reform(freq_mask, 1, n_elements(file_struct.frequencies)), $
+          arr = arr * rebin(reform(freq_mask, 1, n_freq), $
             size(arr, /dimension), /sample)
         endif
 
@@ -305,7 +310,7 @@ pro single_cube_dft, folder_name_in, obs_name, data_subdirs=data_subdirs, $
         arr = arr[*, min(freq_ch_range):max(freq_ch_range)]
       endif
       if n_elements(freq_flags) ne 0 then begin
-        arr = arr * rebin(reform(freq_mask, 1, n_elements(file_struct.frequencies)), $
+        arr = arr * rebin(reform(freq_mask, 1, n_freq), $
         size(arr, /dimension), /sample)
       endif
 

--- a/ps_setup/casa_file_setup.pro
+++ b/ps_setup/casa_file_setup.pro
@@ -254,7 +254,8 @@ function casa_file_setup, filename, pol_inc, save_path = save_path, $
   endif
 
   if n_elements(freq_flags) ne 0 then begin
-    if min(freq_flags) lt 0 or max(freq_flags) gt n_elements(metadata_struct.frequencies) then message, 'invalid freq_ch_range'
+    if min(freq_flags) lt 0 or max(freq_flags) gt n_elements(metadata_struct.frequencies) $
+      then message, 'invalid freq_flags'
   endif
 
   file_tags = create_file_tags(freq_ch_range = freq_ch_range, freq_flags = freq_flags, $

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -1063,6 +1063,9 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     freq_mask = intarr(n_elements(metadata_struct.frequencies)) + 1
     freq_mask[freq_flags] = 0
 
+    if n_elements(freq_ch_range) gt 0 then begin
+      freq_mask = freq_mask[min(freq_ch_range):max(freq_ch_range)]
+    endif
     wh_freq_use = where(freq_mask gt 0, count_freq_use)
     if count_freq_use lt 3 then message, 'Too many frequencies flagged'
 

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -1070,7 +1070,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
 
   if n_elements(freq_flags) ne 0 then begin
     if min(freq_flags) lt 0 or max(freq_flags) gt n_elements(metadata_struct.frequencies) then begin
-      message, 'invalid freq_ch_range'
+      message, 'invalid freq_flags'
     endif
   endif
 

--- a/ps_setup/rts_file_setup.pro
+++ b/ps_setup/rts_file_setup.pro
@@ -567,7 +567,7 @@ function rts_file_setup, filename, save_path = save_path, refresh_info = refresh
 
   if n_elements(freq_flags) ne 0 then begin
     if min(freq_flags) lt 0 or max(freq_flags) gt n_elements(metadata_struct.frequencies) then begin
-      message, 'invalid freq_ch_range'
+      message, 'invalid freq_flags'
     endif
   endif
 


### PR DESCRIPTION
The observation volume calculation was being performed over the full band. If a subband is chosen, it should be calculated only over that subband. 

This does effect the published limits. Thankfully, it is small. For example, lowest limit from Barry et al 2019b for z=7 (lower freqs than average) was 3890.4814 mK^2, but should be 3745.1896 mK^2. I think that means that Wenyang's limits from the z=6.5 band (high freqs than average) should be a little higher than they should be.

I also removed some backwards-compatibility stuff that is probably no longer necessary.