### PR TITLE
ensure uvf_savefilebase has the right dimensionality when n_type is 1

### DIFF
--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -1100,6 +1100,9 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         file_label[pol_i, *]
     endfor
   endfor
+  if n_elements(size(uvf_savefilebase, /dim)) ne 3 then begin
+    uvf_savefilebase = reform(uvf_savefilebase, [npol, nfiles, ntypes])
+  endif
 
   ;; add sw tag to general_filebase so that plotfiles havefile_tags.uvf_tag in them
   general_filebase = metadata_struct.general_filebase + file_tags.uvf_tag


### PR DESCRIPTION
Fixes a bug reported by Zheng, he confirmed it solved the problem.