### PR TITLE
Run in 4pol mode with uvf inputs

### DIFF
--- a/ps_core/ps_main_plots.pro
+++ b/ps_core/ps_main_plots.pro
@@ -31,7 +31,7 @@ pro ps_main_plots, datafile, beamfiles = beamfiles, pol_inc = pol_inc, $
       uvf_input = uvf_input, savefilebase = savefilebase, save_path = save_path, $
       freq_ch_range = freq_ch_range, freq_flags = freq_flags, freq_flag_name = freq_flag_name, $
       refresh_info = refresh_options.refresh_info, uvf_options = uvf_options, $
-      ps_options = ps_options)
+      ps_options = ps_options, pol_inc=pol_inc)
   endelse
   time1 = systime(1)
   print, 'file setup time: ' + number_formatter(time1-time0)

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -636,7 +636,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
           if wt_size[0] ne 2 then begin
             message, 'Weights are in a pointer array, format unknown'
           endif
-          if wt_size[1] ne npol then begin
+          if wt_size[1] lt npol then begin
             message, 'Weights are in a pointer array, format unknown'
           endif
           weights = getvar_savefile(weightfile[pol_i, file_i], weight_varname[pol_i])

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -6,7 +6,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     freq_flag_name = freq_flag_name, $
     save_path = save_path, savefilebase = savefilebase_in, $
     uvf_input = uvf_input, sim = sim, refresh_info = refresh_info, $
-    uvf_options = uvf_options, ps_options = ps_options
+    uvf_options = uvf_options, ps_options = ps_options, pol_inc=pol_inc
 
   ;; check to see if filename is an info file
   wh_info = strpos(filename, '_info.idlsave')
@@ -148,7 +148,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     endif else begin
       ;; no pol identifiers
       if n_elements(pol_inc) eq 0 then pol_inc = ['xx', 'yy']
-      pol_enum = ['xx', 'yy']
+      pol_enum = ['xx', 'yy', 'xy', 'yx']
       npol = n_elements(pol_inc)
       pol_num = intarr(npol)
       for i=0, npol-1 do begin

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -676,7 +676,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
             if var_size[0] ne 2 then begin
               message, 'Variance are in a pointer array, format unknown'
             endif
-            if var_size[1] ne npol then begin
+            if var_size[1] lt npol then begin
               message, 'Variance are in a pointer array, format unknown'
             endif
             variance = getvar_savefile(variancefile[pol_i, file_i], variance_varname[pol_i])

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -583,7 +583,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
               if data_size[0] ne 2 then begin
                 message, 'Data are in a pointer array, format unknown'
               endif
-              if data_size[1] ne npol then begin
+              if data_size[1] lt npol then begin
                 message, 'Data are in a pointer array, format unknown'
               endif
               data = getvar_savefile(datafile[pol_i, file_i], cube_varname[type_i, pol_i])


### PR DESCRIPTION
This PR resolves #139 when the user explicitly passes `pol_inc = ['xx','yy','xy','yx']`. However, we might want to add functionality to allow eppsilon to process only XX and YY cubes when the UVF cubes contain all 4 polarizations. It would also be best to fix the default behavior so the run doesn't error when `pol_inc` is not set.