### PR TITLE
uvf cubes and freq range/flags

### DIFF
--- a/ps_core/ps_image_to_uvf.pro
+++ b/ps_core/ps_image_to_uvf.pro
@@ -42,12 +42,7 @@ pro ps_image_to_uvf, file_struct, n_vis_freq, kx_rad_vals, ky_rad_vals, $
     if (test_uvf eq 1 or test_wt_uvf eq 1) and n_elements(freq_flags) ne 0 then begin
       if test_uvf eq 1 then old_freq_mask = getvar_savefile(file_struct.uvf_savefile[i], 'freq_mask')
       if test_wt_uvf eq 1 then old_freq_mask = getvar_savefile(file_struct.uvf_weight_savefile[i], 'freq_mask')
-      if n_elements(freq_ch_range) ne 0 then begin
-        if total(abs(old_freq_mask[min(freq_ch_range):max(freq_ch_range)] - freq_mask)) ne 0 $
-          then test_uvf = 0
-      endif else begin
-        if total(abs(old_freq_mask - freq_mask)) ne 0 then test_uvf = 0
-      endelse
+      if total(abs(old_freq_mask - freq_mask)) ne 0 then test_uvf = 0
     endif
 
     if test_uvf eq 0 and not refresh_options.refresh_dft and $

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -259,7 +259,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
       endif
     endif
     if n_elements(freq_flags) ne 0 then begin
-      flag_arr = rebin(reform(freq_mask, 1, 1, n_elements(file_struct.frequencies)), $
+      flag_arr = rebin(reform(freq_mask, 1, 1, n_freq), $
         size(weights_cube1,/dimension), /sample)
       weights_cube1 = weights_cube1 * flag_arr
       if nfiles eq 2 then weights_cube2 = weights_cube2 * flag_arr
@@ -313,7 +313,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
           endif
           if n_elements(freq_flags) ne 0 then begin
             nfvis_beam = nfvis_beam*freq_mask
-            flag_arr = rebin(reform(freq_mask, 1, 1, n_elements(file_struct.frequencies)), $
+            flag_arr = rebin(reform(freq_mask, 1, 1, n_freq), $
               size(arr,/dimension), /sample)
             arr = arr * flag_arr
           endif
@@ -565,7 +565,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
         endif
       endif
       if n_elements(freq_flags) ne 0 then begin
-        flag_arr = rebin(reform(freq_mask, 1, 1, n_elements(file_struct.frequencies)), $
+        flag_arr = rebin(reform(freq_mask, 1, 1, n_freq), $
           size(variance_cube1,/dimension), /sample)
         variance_cube1 = variance_cube1 * flag_arr
         if nfiles eq 2 then variance_cube2 = variance_cube2 * flag_arr
@@ -696,7 +696,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
         endif
         if n_elements(freq_flags) ne 0 then begin
           if nfiles eq 2 then begin
-            flag_arr = rebin(reform(freq_mask, 1, n_elements(file_struct.frequencies)), $
+            flag_arr = rebin(reform(freq_mask, 1, n_freq), $
               size(beam_int,/dimension), /sample)
             beam_int = beam_int*flag_arr
             n_vis_freq = n_vis_freq*flag_arr
@@ -828,7 +828,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
         endif
       endif
       if n_elements(freq_flags) ne 0 then begin
-        flag_arr = rebin(reform(freq_mask, 1, 1, n_elements(file_struct.frequencies)), $
+        flag_arr = rebin(reform(freq_mask, 1, 1, n_freq), $
           size(dirty_cube1,/dimension), /sample)
         dirty_cube1 = dirty_cube1 * flag_arr
         model_cube1 = model_cube1 * flag_arr
@@ -898,7 +898,7 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
         endif
       endif
       if n_elements(freq_flags) ne 0 then begin
-        flag_arr = rebin(reform(freq_mask, 1, 1, n_elements(file_struct.frequencies)), $
+        flag_arr = rebin(reform(freq_mask, 1, 1, n_freq), $
           size(data_cube1,/dimension), /sample)
         data_cube1 = data_cube1 * flag_arr
         if nfiles eq 2 then data_cube2 = data_cube2 * flag_arr


### PR DESCRIPTION
uvf cubes didn't have the correct freq_ch_range and freq_flags logic. This isn't a widely used option for uvf cubes, but it's nice to have for comparison purposes.

Frequency channel ranges are determined *before* the frequency flags are applied. The data, model, weights, and all beam options must have the same logic. 

Tested and works with uvf cubes and Healpix cubes with both freq ranges/flags. There was stale Healpix logic (freq flags before freq channel ranges) that has been removed.