### PR TITLE
force double summation

### DIFF
--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -863,7 +863,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         endelse
 
         if j eq 0 then n_vis = dblarr(npol, nfiles)
-        n_vis[pol_i, file_i] = total(obs_arr.n_vis)
+        n_vis[pol_i, file_i] = total(obs_arr.n_vis,/double)
 
         if j eq 0 then n_vis_freq = dblarr(npol, nfiles, n_freq)
         n_vis_freq_arr = dblarr([n_obs[pol_i, file_i], n_freq])


### PR DESCRIPTION
Strange IDL behaviour incoming...

Even if the values within a struct are double, the summation performed over the full struct is not double automatically.

For example, total(obs_arr.n_vis) where obs_arr is a struct array of 160 observations gives 1799498624. The true answer is 1799498646. If you force the total to perform double summation with /double, you get the correct answer. If you were to perform the summation looping over the struct array (i.e. for i=0, 159 do total += obs_arr[i].n_vis) you get the correct answer.

Affects metadata reporting and an extremely small change in some of the normalisation calculations of the beam integral.