### PR TITLE
Fix edge cases

### DIFF
--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -125,13 +125,11 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
   endif
 
   if n_elements(vis_sigma_ian) gt 0 then begin
-    if max(vis_sigma_ian) gt 5. then begin
-      if n_elements(freq_ch_range) ne 0 then begin
-        vis_sigma_ian = vis_sigma_ian[min(freq_ch_range):max(freq_ch_range)]
-      endif
-      vis_sigma = vis_sigma_ian
-      vs_name = 'ian'
+    if n_elements(freq_ch_range) ne 0 then begin
+      vis_sigma_ian = vis_sigma_ian[min(freq_ch_range):max(freq_ch_range)]
     endif
+    vis_sigma = vis_sigma_ian
+    vs_name = 'ian'
   endif
 
   if n_elements(vis_sigma) eq 0 then begin

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -626,6 +626,11 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
         beam_int = file_struct.beam_int
         n_vis_freq = file_struct.n_vis_freq 
 
+        wh_not_finite = where(~finite(beam_int), count=count_not_finite)
+        if count_not_finite gt 0 then begin
+          message, 'some beam_integrals (combine across obs) are not finite'
+        endif
+
         if n_elements(freq_ch_range) ne 0 then begin
           if nfiles eq 2 then begin
             beam_int = beam_int[*,min(freq_ch_range):max(freq_ch_range)]
@@ -664,6 +669,11 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
               total(file_struct.n_vis_freq)
           endelse
         endelse
+
+        wh_not_finite = where(~finite(ave_beam_int), count=count_not_finite)
+        if count_not_finite gt 0 then begin
+          message, 'some frequency averaged beam integrals are not finite'
+        endif
 
         ;; convert rad -> Mpc^2, multiply by depth in Mpc
         window_int_beam_obs = ave_beam_int * z_mpc_mean^2. * (z_mpc_delta * n_freq)
@@ -958,6 +968,12 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
     if tag_exist(file_struct, 'beam_int') then begin
       window_int = window_int_beam_obs
     endif
+
+    wh_not_finite = where(~finite(window_int), count=count_not_finite)
+    if count_not_finite gt 0 then begin
+      message, 'some window integrals are not finite'
+    endif
+
 
     if (n_elements(window_int) eq 0 or min(window_int) eq 0) then begin
       if ps_options.allow_beam_approx then begin

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -611,6 +611,14 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
       message, 'some beam_integrals (combine across obs) are not finite'
     endif
 
+    if min(abs(beam_int)) eq 0 then begin
+      message, 'some beam_integrals (combine across obs) are zero'
+    endif
+
+    if min(abs(n_vis_freq)) eq 0 then begin
+      message, 'some n_vis_freq (combine across obs) are zero'
+    endif
+
     if n_elements(freq_ch_range) ne 0 then begin
       if nfiles eq 2 then begin
         beam_int = beam_int[*,min(freq_ch_range):max(freq_ch_range)]

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -606,19 +606,6 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
     beam_int = file_struct.beam_int
     n_vis_freq = file_struct.n_vis_freq 
 
-    wh_not_finite = where(~finite(beam_int), count_not_finite)
-    if count_not_finite gt 0 then begin
-      message, 'some beam_integrals (combine across obs) are not finite'
-    endif
-
-    if min(abs(beam_int)) eq 0 then begin
-      message, 'some beam_integrals (combine across obs) are zero'
-    endif
-
-    if min(abs(n_vis_freq)) eq 0 then begin
-      message, 'some n_vis_freq (combine across obs) are zero'
-    endif
-
     if n_elements(freq_ch_range) ne 0 then begin
       if nfiles eq 2 then begin
         beam_int = beam_int[*,min(freq_ch_range):max(freq_ch_range)]
@@ -650,10 +637,6 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
 
     wh_not_finite = where(~finite(ave_beam_int), count_not_finite)
     if count_not_finite gt 0 then begin
-      print, "beam_int min/max: " + number_formatter(minmax(beam_int))
-      print, "n_vis_freq min/max: " + number_formatter(minmax(n_vis_freq))
-      print, "beam_int weighted sum: " + number_formatter(ave_beam_numerator)
-      print, "total n_vis: " + number_formatter(ave_beam_denominator)
       message, 'some frequency averaged beam integrals are not finite'
     endif
     ;; convert rad -> Mpc^2, multiply by depth in Mpc

--- a/ps_core/ps_kcube.pro
+++ b/ps_core/ps_kcube.pro
@@ -1172,8 +1172,10 @@ pro ps_kcube, file_struct, sim = sim, fix_sim_input = fix_sim_input, $
       ;; reduction in the mean that should happen when the window is applied
       data_sum_mean = data_sum_mean / norm_factor
       sim_noise_sum_mean = sim_noise_sum_mean / norm_factor
-      data_diff_mean = data_diff_mean / norm_factor
-      sim_noise_diff_mean = sim_noise_diff_mean / norm_factor
+      if nfiles eq 2 then begin
+        data_diff_mean = data_diff_mean / norm_factor
+        sim_noise_diff_mean = sim_noise_diff_mean / norm_factor
+      endif
     endif
 
     window_expand = rebin(reform(window, 1, 1, n_freq), n_kx, n_ky, n_freq, /sample)

--- a/ps_plotting/cube_images.pro
+++ b/ps_plotting/cube_images.pro
@@ -210,7 +210,7 @@ pro cube_images, folder_names, obs_info, nvis_norm = nvis_norm, $
   if keyword_set(rts) then pixel_varnames = strarr(n_elements(filenames)) + 'pixel_nums' $
   else pixel_varnames = strarr(n_elements(filenames)) + 'hpx_inds'
   
-  pol_exist = stregex(filenames, '[xy][xy]', /boolean, /fold_case)
+  pol_exist = stregex(file_basename(filenames), '[xy][xy]', /boolean, /fold_case)
   
   if keyword_set(png) or keyword_set(eps) or keyword_set(pdf) then pub = 1 else pub = 0
   if pub then begin

--- a/ps_plotting/cube_images.pro
+++ b/ps_plotting/cube_images.pro
@@ -293,12 +293,21 @@ pro cube_images, folder_names, obs_info, nvis_norm = nvis_norm, $
       endfor
     endif else n_vis_freq_avg = nvis_freq
     cube1 = cube1 / rebin(reform(n_vis_freq_avg, 1, n_freq1), n_elements(hpx_inds1), n_freq1)
+    if min(n_vis_freq_avg) eq 0 then begin
+      cube1[*, where(n_vis_freq_avg eq 0)] = 0
+    endif
     if cube_types[0] ne 'weights' and cube_types[0] ne 'variances' and $
       cube_types[max_type] ne 'weights' and cube_types[max_type] ne 'variances' then begin
       weights1 = getvar_savefile(filenames[0], weight_varnames[0])
       weights1 = weights1 / rebin(reform(n_vis_freq_avg, 1, n_freq1), n_elements(hpx_inds1), n_freq1)
-      
-      cube1 = cube1 / rebin(reform(max(weights1, dimension=1), 1, n_freq1), n_elements(hpx_inds1), n_freq1)
+      if min(n_vis_freq_avg) eq 0 then begin
+        weights1[*, where(n_vis_freq_avg eq 0)] = 0
+      endif
+      max_wt_freq = max(weights1, dimension=1)
+      cube1 = cube1 / rebin(reform(max_wt_freq, 1, n_freq1), n_elements(hpx_inds1), n_freq1)
+      if min(max_wt_freq) eq 0 then begin
+        cube1[*, where(max_wt_freq eq 0)] = 0
+      endif
       units_str = 'Jy/beam'
     endif
   endif
@@ -329,17 +338,32 @@ pro cube_images, folder_names, obs_info, nvis_norm = nvis_norm, $
           else n_vis_freq_avg[i] = total(nvis_freq[inds_use])
         endfor
       endif else n_vis_freq_avg = nvis_freq
-      if n_elements(filenames) eq 2 then $
-        cube2 = cube2 / rebin(reform(n_vis_freq_avg, 1, n_freq2), n_elements(hpx_inds2), n_freq2) $
-      else cube2 = cube2 / rebin(reform(n_vis_freq_avg, 1, n_freq2), n_elements(hpx_inds1), n_freq2)
+      if n_elements(filenames) eq 2 then begin
+        cube2 = cube2 / rebin(reform(n_vis_freq_avg, 1, n_freq2), n_elements(hpx_inds2), n_freq2)
+      endif else begin
+        cube2 = cube2 / rebin(reform(n_vis_freq_avg, 1, n_freq2), n_elements(hpx_inds1), n_freq2)
+      endelse
+      if min(n_vis_freq_avg) eq 0 then begin
+        cube2[*, where(n_vis_freq_avg eq 0)] = 0
+      endif
+
       if cube_types[0] ne 'weights' and cube_types[0] ne 'variances' and $
         cube_types[max_type] ne 'weights' and cube_types[max_type] ne 'variances' then begin
         
         weights2 = getvar_savefile(filenames[max_file], weight_varnames[max_type])
         weights2 = weights2 / rebin(reform(n_vis_freq_avg, 1, n_freq1), n_elements(hpx_inds1), n_freq1)
-        if n_elements(filenames) eq 2 then $
-          cube2 = cube2 / rebin(reform(max(weights2, dimension=1), 1, n_freq1), n_elements(hpx_inds2), n_freq2) $
-        else cube2 = cube2 / rebin(reform(max(weights2, dimension=1), 1, n_freq1), n_elements(hpx_inds1), n_freq2)
+        if min(n_vis_freq_avg) eq 0 then begin
+          weights2[*, where(n_vis_freq_avg eq 0)] = 0
+        endif
+        max_wt_freq = max(weights2, dimension=1)
+        if n_elements(filenames) eq 2 then begin
+          cube2 = cube2 / rebin(reform(max_wt_freq, 1, n_freq1), n_elements(hpx_inds2), n_freq2)
+        endif else begin
+          cube2 = cube2 / rebin(reform(max_wt_freq, 1, n_freq1), n_elements(hpx_inds1), n_freq2)
+        endelse
+        if min(max_wt_freq) eq 0 then begin
+          cube2[*, where(max_wt_freq eq 0)] = 0
+        endif
       endif
     endif
   endif

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -959,21 +959,12 @@ function fhd_file_setup, filename, weightfile = weightfile, $
             if min(beam_int_arr) eq 0 then begin
               message, 'some beam_integrals are null, others are not.'
             endif
-            wh_not_finite = where(finite(beam_int_arr) lt 1, count_not_finite)
-            if count_not_finite gt 0 then begin
-              message, 'some beam_integrals in obs_arr are not finite'
-            endif
 
             wh_freq_all_0 = where(total(n_vis_freq_arr, 1) eq 0, count_freq_all_0)
             beam_int[pol_i, file_i, *] = total(beam_int_arr * n_vis_freq_arr, 1) / $
               total(n_vis_freq_arr, 1)
             if count_freq_all_0 gt 0 then beam_int[pol_i, file_i, wh_freq_all_0]=0
           endelse
-          if n_elements(beam_int) gt 0 then begin
-            if min(abs(beam_int)) eq 0 then begin
-                message, 'some beam_integrals (combined across obs) are null, others are not.'
-            endif
-          endif
         endif
 
         if tag_exist(obs_arr[0], 'vis_noise') then begin
@@ -1008,10 +999,6 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         endif
 
         n_vis_freq[pol_i, file_i, *] = total(n_vis_freq_arr, 1)
-        if min(n_vis_freq) eq 0 then begin
-            message, 'some n_vis_freq values are zero.'
-        endif
-
         undefine_fhd, obs_arr
       endif else begin
         message, 'no obs or obs_arr in datafile'
@@ -1091,14 +1078,6 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       if n_elements(beam_int) gt 0 then beam_int = beam_int_avg
 
       n_vis_freq = n_vis_freq_avg
-      if min(abs(beam_int)) eq 0 then begin
-        message, 'some beam_integrals after accounting for FHD freq averaging are zero'
-      endif
-
-      if min(abs(n_vis_freq)) eq 0 then begin
-        message, 'some n_vis_freq after accounting for FHD freq averaging are zero'
-      endif
-
     endif else begin
       frequencies = freq / 1e6 ;; in MHz
     endelse

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -899,7 +899,10 @@ function fhd_file_setup, filename, weightfile = weightfile, $
 
         dt_vals = dblarr(n_obs[pol_i, file_i])
         wh_timeres = where(strlowcase(obs_tags) eq 'time_res', count_timeres)
-        if count_timeres ne 0 then dt_vals = obs_arr.time_res else begin
+        if count_timeres ne 0 then begin
+          ;; use the abs in case the times are arranged in descending order
+          dt_vals = abs(obs_arr.time_res)
+        endif else begin
           for i=0, n_obs[pol_i, file_i]-1 do begin
             times = (*obs_arr[i].baseline_info).jdate
             ;; only allow time resolutions of n*.5 sec

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -111,29 +111,29 @@ function fhd_file_setup, filename, weightfile = weightfile, $
     if n_elements(datafile) eq 0 then datafile = filename
 
     ;; check whether datafiles have polarization identifiers in filename
-    pol_exist = stregex(datafile, '[xy][xy]', /boolean, /fold_case)
+    pol_exist = stregex(file_basename(datafile), '[xy][xy]', /boolean, /fold_case)
     if max(pol_exist) gt 0 then begin
       wh_pol_exist = where(pol_exist gt 0, count_pol_exist, ncomplement = count_no_pol)
       if count_no_pol gt 0 then begin
         message, 'some datafiles have pol identifiers and some do not'
       endif
-      pols = strlowcase(stregex(datafile, '[xy][xy]', /extract, /fold_case))
+      pols = strlowcase(stregex(file_basename(datafile), '[xy][xy]', /extract, /fold_case))
       if n_elements(weightfile) gt 0 then begin
-        wt_pols = strlowcase(stregex(weightfile, '[xy][xy]', /extract, /fold_case))
+        wt_pols = strlowcase(stregex(file_basename(weightfile), '[xy][xy]', /extract, /fold_case))
         match, pols, wt_pols, suba, subb, count = count_pol_match
         if count_pol_match ne n_elements(pols) then begin
           message, 'weightfile polarizations must match datafile polarizations'
         endif
       endif
       if n_elements(variancefile) gt 0 then begin
-        var_pols = strlowcase(stregex(variancefile, '[xy][xy]', /extract, /fold_case))
+        var_pols = strlowcase(stregex(file_basename(variancefile), '[xy][xy]', /extract, /fold_case))
         match, pols, var_pols, suba, subb, count = count_pol_match
         if count_pol_match ne n_elements(pols) then begin
           message, 'variancefile polarizations must match datafile polarizations'
         endif
       endif
       if n_elements(beamfile) gt 0 then begin
-        bm_pols = strlowcase(stregex(beamfile, '[xy][xy]', /extract, /fold_case))
+        bm_pols = strlowcase(stregex(file_basename(beamfile), '[xy][xy]', /extract, /fold_case))
         match, pols, bm_pols, suba, subb, count = count_pol_match
         if count_pol_match ne n_elements(pols) then begin
           message, 'beamfile polarizations must match datafile polarizations'
@@ -1130,7 +1130,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
   if tag_exist(metadata_struct, 'nside') then healpix = 1 else healpix = 0
   if tag_exist(metadata_struct, 'no_var') then no_var = 1 else no_var = 0
 
-  pol_exist = stregex(metadata_struct.datafile, '[xy][xy]', /boolean, /fold_case)
+  pol_exist = stregex(file_basename(metadata_struct.datafile), '[xy][xy]', /boolean, /fold_case)
 
   if n_elements(freq_flags) ne 0 then begin
     freq_mask = intarr(n_elements(metadata_struct.frequencies)) + 1

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -969,6 +969,11 @@ function fhd_file_setup, filename, weightfile = weightfile, $
               total(n_vis_freq_arr, 1)
             if count_freq_all_0 gt 0 then beam_int[pol_i, file_i, wh_freq_all_0]=0
           endelse
+          if n_elements(beam_int) gt 0 then begin
+            if min(beam_int) eq 0 then begin
+                message, 'some beam_integrals are null, others are not.'
+            endif
+          endif
         endif
 
         if tag_exist(obs_arr[0], 'vis_noise') then begin
@@ -1001,6 +1006,9 @@ function fhd_file_setup, filename, weightfile = weightfile, $
         endif
 
         n_vis_freq[pol_i, file_i, *] = total(n_vis_freq_arr, 1)
+        if min(n_vis_freq) eq 0 then begin
+            message, 'some n_vis_freq values are zero.'
+        endif
 
         undefine_fhd, obs_arr
       endif else begin

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -959,6 +959,10 @@ function fhd_file_setup, filename, weightfile = weightfile, $
             if min(beam_int_arr) eq 0 then begin
               message, 'some beam_integrals are null, others are not.'
             endif
+            wh_not_finite = where(~finite(beam_int_arr), count=count_not_finite)
+            if count_not_finite gt 0 then begin
+              message, 'some beam_integrals in obs_arr are not finite'
+            endif
 
             wh_freq_all_0 = where(total(n_vis_freq_arr, 1) eq 0, count_freq_all_0)
             beam_int[pol_i, file_i, *] = total(beam_int_arr * n_vis_freq_arr, 1) / $

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -195,8 +195,19 @@ function fhd_file_setup, filename, weightfile = weightfile, $
       beamfile = temporary(temp_bm)
       pixelfile = temporary(temp_pix)
     endif else begin
-      ;; no pol identifiers
-      if n_elements(pol_inc) eq 0 then pol_inc = ['xx', 'yy']
+      ;; no pol identifiers in filenames
+      if n_elements(pol_inc) eq 0 then begin
+        void = getvar_savefile(datafile[0], names = datafile_varnames)
+        wh_weights = where(strmatch(datafile_varnames, 'weights*',/fold_case) gt 0, count_weights)
+        if count_weights eq 0 then message, 'no weights array in file'
+        if count_weights eq 1 then begin
+          ;; FHD only allows xx if one pol
+          pol_inc = ['xx']
+        endif else begin
+          ;; defaut to 'xx' and 'yy' if npol >= 2
+          pol_inc = ['xx', 'yy']
+        endelse
+      endif
       pol_enum = ['xx', 'yy', 'xy', 'yx']
       npol = n_elements(pol_inc)
       pol_num = intarr(npol)

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -970,7 +970,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
             if count_freq_all_0 gt 0 then beam_int[pol_i, file_i, wh_freq_all_0]=0
           endelse
           if n_elements(beam_int) gt 0 then begin
-            if min(beam_int) eq 0 then begin
+            if min(abs(beam_int)) eq 0 then begin
                 message, 'some beam_integrals (combined across obs) are null, others are not.'
             endif
           endif

--- a/ps_setup/fhd_file_setup.pro
+++ b/ps_setup/fhd_file_setup.pro
@@ -959,7 +959,7 @@ function fhd_file_setup, filename, weightfile = weightfile, $
             if min(beam_int_arr) eq 0 then begin
               message, 'some beam_integrals are null, others are not.'
             endif
-            wh_not_finite = where(~finite(beam_int_arr), count=count_not_finite)
+            wh_not_finite = where(finite(beam_int_arr) lt 1, count_not_finite)
             if count_not_finite gt 0 then begin
               message, 'some beam_integrals in obs_arr are not finite'
             endif


### PR DESCRIPTION
This cleans up a bunch of minor bugs that broke things in recent runs:
- properly detect npol if no polnames in filenames
- handle descending time order in time resolution calculation
- Always use the vis_sigma calculated by FHD if it is available
- Only use the file basename when parsing polarizations out of filenames
- properly handle fully flagged frequencies in cube image plotting
- Fix a bug when we only have one file (no even/odd split)
- Properly handle a null pointer in for `vis_noise` in the obs structure (happens with only one time).
- Fix a bug in beam integral handling for single times (no vis_noise in obs structure), also generally clean up beam integral handling.